### PR TITLE
use proper header links in stage

### DIFF
--- a/.env.stage
+++ b/.env.stage
@@ -1,4 +1,4 @@
-SITE_TITLE=DataCite DOI Fabrica
+SITE_TITLE=DataCite Test DOI Fabrica
 NAVMENU_TITLE=Test Services
 ORCID_URL=https://sandbox.orcid.org
 API_URL=https://api.test.datacite.org

--- a/app/components/application-header.js
+++ b/app/components/application-header.js
@@ -53,7 +53,13 @@ export default Ember.Component.extend({
     fetch(url).then(function(response) {
       return response.json();
     }).then(function(data) {
-      data.header_links = data[ENV.environment + '_links'];
+      if (ENV.BUGSNAG_RELEASE_STAGE === "production") {
+        data.header_links = data.production_links;
+      } else if (ENV.BUGSNAG_RELEASE_STAGE === "staging") {
+        data.header_links = data.stage_links;
+      } else {
+        data.header_links = data.development_links;
+      }
       self.set('data', data);
     });
   }


### PR DESCRIPTION
`ENV.environment` is the same for `stage` and `production` deployments.