### PR TITLE
show proper error message for accounts that have been deleted. #54

### DIFF
--- a/app/controllers/clients/index.js
+++ b/app/controllers/clients/index.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  queryParams: ['query', 'year', 'provider-id', 'sort', 'page', 'perPage'],
+  queryParams: ['query', 'year', 'provider-id', 'include-deleted', 'sort', 'page', 'perPage'],
   query: null,
   year: null,
   'provider-id': null,
+  'include-deleted': null,
   sort: null
 });

--- a/app/controllers/providers/index.js
+++ b/app/controllers/providers/index.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  queryParams: ['query', 'region', 'organization-type', 'focus-area', 'year', 'sort', 'page', 'perPage'],
+  queryParams: ['query', 'region', 'organization-type', 'focus-area', 'include-deleted', 'year', 'sort', 'page', 'perPage'],
   query: null,
   region: null,
   'organization-type': null,
   'focus-area': null,
+  'include-deleted': null,
   year: null,
   sort: null
 });

--- a/app/validators/unique-client-id.js
+++ b/app/validators/unique-client-id.js
@@ -9,9 +9,9 @@ const UniqueClientId = BaseValidator.extend({
     if (value === providerId || Ember.computed.not('model.meta.id.isEnabled')) {
       return true;
     } else {
-      return this.get('store').query('client', { id: value }).then((result) => {
+      return this.get('store').query('client', { query: value, 'include-deleted': true }).then((result) => {
         if(result.content.length > 0) {
-          return "The Client ID " + value + " already exists.";
+          return "The Client ID " + value + " already exists, or existed before and has been deleted. Please contact DataCite staff if you want to create an account with this Client ID.";
         } else {
           return true;
         }

--- a/app/validators/unique-provider-id.js
+++ b/app/validators/unique-provider-id.js
@@ -8,9 +8,9 @@ const UniqueProviderId = BaseValidator.extend({
     if (value.length < 2 || model && Ember.computed.not('model.meta.id.isEnabled')) {
       return true;
     } else {
-      return this.get('store').query('provider', { id: value }).then((result) => {
+      return this.get('store').query('provider', { query: value, 'include-deleted': true }).then((result) => {
         if(result.content.length > 0) {
-          return "The Provider ID " + value + " already exists.";
+          return "The Provider ID " + value + " already exists, or existed before and has been deleted. Please contact DataCite staff if you want to create an account with this Provider ID.";
         } else {
           return true;
         }


### PR DESCRIPTION
Updated the API call to include deleted accounts, and show this error message: 

```
The Client ID xxx already exists, or existed before and has been deleted. Please contact DataCite staff if you want to create an account with this Client ID.
```