### PR TITLE
Feature language field

### DIFF
--- a/app/components/doi-language.js
+++ b/app/components/doi-language.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import ISO6391 from 'iso-639-1';
+
+
+const languageList = ISO6391.getAllNames();
+
+export default Component.extend({
+  languageList,
+  languages: languageList,
+  language: computed('model.language', function() {
+    return ISO6391.getName(this.get('model.language'));
+  }),
+
+
+  actions: {
+    searchLanguage(query) {
+      let languages = languageList.filter(function(language) {
+        return language.toLowerCase().startsWith(query.toLowerCase());
+      });
+      this.set('languages', languages);
+    },
+    selectLanguage(language) {
+      if (language) {
+        this.model.set('language', ISO6391.getCode(language));
+      } else {
+        this.model.set('language', null);
+      }
+      this.set('languages', languageList);
+    },
+  },
+});

--- a/app/controllers/dois/show/edit.js
+++ b/app/controllers/dois/show/edit.js
@@ -52,6 +52,11 @@ export default Controller.extend({
         }
       });
 
+      // // only store descriptions with a description text
+      // doi.set('language', A(doi.get('language')).filter(function(language) {
+      //   return !isBlank(language);
+      // }));
+
       // only store descriptions with a description text
       doi.set('descriptions', A(doi.get('descriptions')).filter(function(description) {
         return !isBlank(description.description);

--- a/app/controllers/repositories/show/dois/new.js
+++ b/app/controllers/repositories/show/dois/new.js
@@ -42,6 +42,11 @@ export default Controller.extend({
         return !isBlank(description.description);
       }));
 
+      // only store descriptions with a description text
+      // doi.set('language', A(doi.get('language')).filter(function(language) {
+      //   return !isBlank(language);
+      // }));
+
       // only store titles with a title text
       doi.set('titles', A(doi.get('titles')).filter(function(title) {
         return !isBlank(title.title);

--- a/app/models/doi.js
+++ b/app/models/doi.js
@@ -150,7 +150,7 @@ export default DS.Model.extend(Validations, {
   subjects: DS.attr(),
   contributors: DS.attr(),
   dates: DS.attr(),
-  language: DS.attr(),
+  language: DS.attr('string'),
   types: DS.attr(),
   relatedIdentifiers: DS.attr(),
   sizes: DS.attr(),

--- a/app/serializers/doi.js
+++ b/app/serializers/doi.js
@@ -27,7 +27,7 @@ export default ApplicationSerializer.extend({
     subjects: { serialize: false },
     contributors: { serialize: false },
     dates: { serialize: false },
-    language: { serialize: false },
+    // language: { serialize: false },
     relatedIdentifiers: { serialize: false },
     sizes: { serialize: false },
     formats: { serialize: false },

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -71,6 +71,7 @@ export default Service.extend({
 
         this.features.setup({
           'show-researchers': true,
+          'optional-fields': true,
         });
       } else if (payload.role_id === 'provider_admin') {
         this.set('isProvider', true);
@@ -97,6 +98,7 @@ export default Service.extend({
       if (payload.beta_tester) {
         this.features.setup({
           'show-researchers': true,
+          'optional-fields': true,
         });
       }
 

--- a/app/templates/components/doi-language.hbs
+++ b/app/templates/components/doi-language.hbs
@@ -2,11 +2,13 @@
   <label class="control-label col-md-3">Language (optional)</label>
 
   <div class="col-md-9">
-    <div class="power-select doi-language">
-      {{#form.element controlType="power-select" disabled=disabled value=language options=languages as |el|}}
-      {{el.control class="doi-language" onChange=(action "selectLanguage") search=(action "searchLanguage") placeholder="Select Language" searchPlaceholder="Type to search..." allowClear=true }}
-      {{/form.element}}
-    </div>
+     {{!-- <div class="input-group"> --}}
+      {{!-- <span class="input-group-addon"> --}}
+    {{#form.element controlType="power-select" id="doi-language" formLayout="vertical"  disabled=disabled value=language options=languages as |el|}}
+      {{el.control onChange=(action "selectLanguage") search=(action "searchLanguage") placeholder="Select Language" searchPlaceholder="Type to search..." allowClear=true }}
+    {{/form.element}}
+      {{!-- </span> --}}
+    {{!-- </div> --}}
     <div class="help-block help-block doi-language">The primary language of the resource.</div>
   </div>
 </div>

--- a/app/templates/components/doi-language.hbs
+++ b/app/templates/components/doi-language.hbs
@@ -1,0 +1,12 @@
+<div class="form-group {{validationClass}}">
+  <label class="control-label col-md-3">Language (optional)</label>
+
+  <div class="col-md-9">
+    <div class="power-select doi-language">
+      {{#form.element controlType="power-select" disabled=disabled value=language options=languages as |el|}}
+      {{el.control class="doi-language" onChange=(action "selectLanguage") search=(action "searchLanguage") placeholder="Select Language" searchPlaceholder="Type to search..." allowClear=true }}
+      {{/form.element}}
+    </div>
+    <div class="help-block help-block doi-language">The primary language of the resource.</div>
+  </div>
+</div>

--- a/app/templates/dois/show/edit.hbs
+++ b/app/templates/dois/show/edit.hbs
@@ -28,9 +28,10 @@
 
       <DoiTypes @model={{model}} @form={{form}} />
       <DoiDescriptions @model={{model}} @form={{form}} />
-
-      <DoiLanguage @model={{model}} @form={{form}} />
-
+      
+      {{#if (feature-flag 'optionalFields')}}
+        <DoiLanguage @model={{model}} @form={{form}} />
+      {{/if}}
 
       <div class="col-md-9 col-md-offset-3">
         {{#if (is-empty (doi-form-errors model))}}

--- a/app/templates/dois/show/edit.hbs
+++ b/app/templates/dois/show/edit.hbs
@@ -29,6 +29,9 @@
       <DoiTypes @model={{model}} @form={{form}} />
       <DoiDescriptions @model={{model}} @form={{form}} />
 
+      <DoiLanguage @model={{model}} @form={{form}} />
+
+
       <div class="col-md-9 col-md-offset-3">
         {{#if (is-empty (doi-form-errors model))}}
           <button type="submit" id="doi-update" class="btn btn-sm btn-fill" disabled={{false}}>Update DOI</button>

--- a/app/templates/repositories/show/dois/new.hbs
+++ b/app/templates/repositories/show/dois/new.hbs
@@ -21,7 +21,9 @@
       <DoiTypes @model={{model.doi}} @form={{form}} />
       <DoiDescriptions @model={{model.doi}} @form={{form}} />
 
-      <DoiLanguage @model={{model.doi}} @form={{form}} />
+      {{#if (feature-flag 'optionalFields')}}
+        <DoiLanguage @model={{model.doi}} @form={{form}} />
+      {{/if}}
 
       <div class="col-md-9 col-md-offset-3">
         {{#if (is-empty (doi-form-errors model.doi))}}

--- a/app/templates/repositories/show/dois/new.hbs
+++ b/app/templates/repositories/show/dois/new.hbs
@@ -21,6 +21,8 @@
       <DoiTypes @model={{model.doi}} @form={{form}} />
       <DoiDescriptions @model={{model.doi}} @form={{form}} />
 
+      <DoiLanguage @model={{model.doi}} @form={{form}} />
+
       <div class="col-md-9 col-md-offset-3">
         {{#if (is-empty (doi-form-errors model.doi))}}
           <button type="submit" id="doi-create" class="btn btn-sm btn-fill" disabled={{false}}>Create DOI</button>

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,6 +43,7 @@ module.exports = function(environment) {
     },
     featureFlags: {
       'show-researchers': false,
+      'optional-fields': false,
     },
     fastboot: {
       hostWhitelist: [ 'doi.datacite.org', 'doi.test.datacite.org', /^10\.0\.\d{1,3}\.\d{1,3}$/, /^localhost:\d+$/ ],
@@ -112,6 +113,7 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
 
     ENV.featureFlags['show-researchers'] = true;
+    ENV.featureFlags['optional-fields'] = true;
 
     ENV.APP.autoboot = false;
 

--- a/tests/acceptance/client_admin/doi-test.js
+++ b/tests/acceptance/client_admin/doi-test.js
@@ -15,6 +15,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupFactoryGuy } from 'ember-data-factory-guy';
 // import { build, make, mockFindRecord } from 'ember-data-factory-guy';
 // import ENV from 'bracco/config/environment';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
 
 module('Acceptance | client_admin | repository', function(hooks) {
   setupApplicationTest(hooks);
@@ -58,5 +59,34 @@ module('Acceptance | client_admin | repository', function(hooks) {
 
     assert.equal(currentURL(), '/dois/10.70048%2Fe605-dg05');
     assert.dom('h2.work').hasText('10.70048/e605-dg05');
+  });
+
+  test('visiting specific doi in the Form', async function(assert) {
+    await authenticateSession({
+      uid: 'datacite.rph',
+      name: 'Alfred Wegener Institute',
+      role_id: 'client_admin',
+      provider_id: 'datacite',
+      client_id: 'datacite.rph',
+    });
+    await visit('/dois/10.70048%2Fe605-dg05/edit');
+
+    assert.equal(currentURL(), '/dois/10.70048%2Fe605-dg05/edit');
+    assert.dom('#doi-language').includesText('French');
+  });
+
+  test('visiting the Form and selecting language', async function(assert) {
+    await authenticateSession({
+      uid: 'datacite.rph',
+      name: 'Alfred Wegener Institute',
+      role_id: 'client_admin',
+      provider_id: 'datacite',
+      client_id: 'datacite.rph',
+    });
+    await visit('repositories/datacite.rph/dois/new');
+
+    await selectChoose('#doi-language', 'English');
+    assert.equal(currentURL(), 'repositories/datacite.rph/dois/new');
+    assert.dom('#doi-language').includesText('English');
   });
 });

--- a/tests/acceptance/staff_admin/doi-test.js
+++ b/tests/acceptance/staff_admin/doi-test.js
@@ -64,7 +64,7 @@ module('Acceptance | staff_admin | admin', function(hooks) {
   // });
 
   test('new DOI form for repository RPH', async function(assert) {
-    assert.expect(14);
+    assert.expect(15);
 
     await visit('/repositories/datacite.rph/dois/new');
 
@@ -85,6 +85,7 @@ module('Acceptance | staff_admin | admin', function(hooks) {
     assert.dom('input#publication-year-field').exists();
     assert.dom('input#resource-type-field').exists();
     assert.dom('[data-test-description]').exists();
+    assert.dom('#doi-language').exists();
 
     assert.dom('button#doi-create').exists();
   });
@@ -106,31 +107,32 @@ module('Acceptance | staff_admin | admin', function(hooks) {
     assert.dom('button#doi-create').exists();
   });
 
-  // test('edit DOI form for repository RPH', async function(assert) {
-  //   assert.expect(14);
+  test('edit DOI form for repository RPH', async function(assert) {
+    assert.expect(15);
 
-  //   await visit('/dois/10.70048%2Fe605-dg05/edit');
+    await visit('/dois/10.70048%2Fe605-dg05/edit');
 
-  //   assert.equal(currentURL(), '/dois/10.70048%2Fe605-dg05/edit');
-  //   assert.dom('input#doi-field').exists();
-  //   // assert.dom('input#draft-radio').exists();
+    assert.equal(currentURL(), '/dois/10.70048%2Fe605-dg05/edit');
+    assert.dom('input#doi-field').exists();
+    // assert.dom('input#draft-radio').exists();
 
-  //   assert.dom('input#url-field').exists();
+    assert.dom('input#url-field').exists();
 
-  //   assert.dom('[data-test-name-identifier]').exists();
-  //   assert.dom('input.select-person').exists();
-  //   assert.dom('[data-test-given-name]').exists();
-  //   assert.dom('[data-test-family-name]').exists();
-  //   assert.dom('[data-test-name]').exists();
+    assert.dom('[data-test-name-identifier]').exists();
+    assert.dom('input.select-person').exists();
+    assert.dom('[data-test-given-name]').exists();
+    assert.dom('[data-test-family-name]').exists();
+    assert.dom('[data-test-name]').exists();
 
-  //   assert.dom('[data-test-title]').exists();
-  //   assert.dom('input#publisher-field').exists();
-  //   assert.dom('input#publication-year-field').exists();
-  //   assert.dom('input#resource-type-field').exists();
-  //   assert.dom('[data-test-description]').exists();
+    assert.dom('[data-test-title]').exists();
+    assert.dom('input#publisher-field').exists();
+    assert.dom('input#publication-year-field').exists();
+    assert.dom('input#resource-type-field').exists();
+    assert.dom('[data-test-description]').exists();
+    assert.dom('#doi-language').exists();
 
-  //   assert.dom('button#doi-update').exists();
-  // });
+    assert.dom('button#doi-update').exists();
+  });
 
   // TODO fix validations
   // test('modify DOI form for repository RPH', async function(assert) {

--- a/tests/factories/doi.js
+++ b/tests/factories/doi.js
@@ -20,6 +20,7 @@ FactoryGuy.define('doi', {
     created: '2017-09-27T14:08:02.000Z',
     registered: '2017-09-27T14:08:02.000Z',
     updated: '2017-09-27T14:08:02.000Z',
+    language: 'en',
     downloadCount: 4,
     viewCount: 111111,
     citationCount: 123,

--- a/tests/integration/components/doi-language-test.js
+++ b/tests/integration/components/doi-language-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+// import { selectChoose } from 'ember-power-select/test-support/helpers';
+
+
+import { setupFactoryGuy, make } from 'ember-data-factory-guy';
+
+module('Integration | Component | doi language', function(hooks) {
+  setupRenderingTest(hooks);
+  setupFactoryGuy(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('model', make('doi'));
+    console.log(this.set('model', make('doi')));
+    await render(hbs`{{doi-language model=model.doi}}`);
+    // await selectChoose('.doi-language', '.ember-power-select-option', 'English');
+
+
+    assert.dom('*').hasText('Language (optional)  The primary language of the resource.');
+
+
+    // assert.dom('.ember-power-select-selected-item').hasText('English');
+  });
+});

--- a/tests/integration/components/doi-language-test.js
+++ b/tests/integration/components/doi-language-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-// import { selectChoose } from 'ember-power-select/test-support/helpers';
 
 
 import { setupFactoryGuy, make } from 'ember-data-factory-guy';
@@ -15,12 +14,7 @@ module('Integration | Component | doi language', function(hooks) {
     this.set('model', make('doi'));
     console.log(this.set('model', make('doi')));
     await render(hbs`{{doi-language model=model.doi}}`);
-    // await selectChoose('.doi-language', '.ember-power-select-option', 'English');
-
 
     assert.dom('*').hasText('Language (optional)  The primary language of the resource.');
-
-
-    // assert.dom('.ember-power-select-selected-item').hasText('English');
   });
 });


### PR DESCRIPTION
## Description
addresses: https://github.com/datacite/bracco/issues/323

> As a Fabrica administrator
> I want to be able to select language metadata in an error-free fashion from the ISO369 controlled list
> So that I can have consistent language metadata in my dois metadata


## List of General Components affected
- feature flag config
- integration test
- new lang component
- routes for new and edit
- serialiser

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Non Functional Requirement
- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] All new and existing tests passed.
- [ ] Documentation
