### PR TITLE
support info-uri for rights

### DIFF
--- a/app/models/rights.js
+++ b/app/models/rights.js
@@ -7,7 +7,7 @@ const Validations = buildValidations({
   rightsUri: [
     validator('url-format', {
       allowBlank: true,
-      protocols: [ 'http','https','ftp', 'info' ],
+      protocols: [ 'http','https','ftp' ],
       message: 'Rights scheme URI has to be a valid URI',
       // disable url check for info URI
       // disabled: computed('fragment.rightsUri', function() {

--- a/app/validators/url-format.js
+++ b/app/validators/url-format.js
@@ -8,6 +8,9 @@ const UrlFormat = BaseValidator.extend({
     } else if (!value) {
       let message = 'This field can\'t be blank.';
       return message;
+    // don't validate info URIs (not handled by validator)
+    } else if (value.startsWith('info:')) {
+      return true;
     } else {
       // default options for this validator, require_protocol set to true
       let defaultOptions = { protocols: [ 'http','https','ftp' ], require_tld: true, require_protocol: true, require_host: true, require_valid_protocol: true, allow_underscores: false, host_whitelist: false, host_blacklist: false, allow_trailing_dot: false, allow_protocol_relative_urls: false, disallow_auth: false };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "langs": "^2.0.0",
     "mime": "^2.4.4",
     "pascal-case": "^3.1.1",
-    "validator": "^12.1.0"
+    "validator": "^13.0.0"
   },
   "fastbootDependencies": [
     "node-fetch",

--- a/tests/unit/validators/url-format-test.js
+++ b/tests/unit/validators/url-format-test.js
@@ -64,18 +64,14 @@ module('Unit | Validator | url-format', function(hooks) {
     assert.equal(message, 'Please enter a valid URL.');
   });
 
-  // test('info uri', function(assert) {
-  //   assert.expect(1);
+  test('info uri', function(assert) {
+    assert.expect(1);
 
-  //   options = {
-  //     require_host: false,
-  //     protocols: [ 'http','https','info' ],
-  //   };
-  //   options = validator.buildOptions(options, {}).toObject();
+    builtOptions = validator.buildOptions({}).toObject();
 
-  //   message = validator.validate('info:eu-repo/semantics/openAccess', options);
-  //   assert.equal(message, true);
-  // });
+    message = validator.validate('info:eu-repo/semantics/openAccess', builtOptions);
+    assert.equal(message, true);
+  });
 
   test('allow blank', function(assert) {
     assert.expect(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15646,10 +15646,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-12.1.0.tgz#a3a7315d5238cbc15e46ad8d5e479aafa7119925"
-  integrity sha512-gIC2RBuFRi574Rb9vewGCJ7TCLxHXNx6EKthEgs+Iz0pYa9a9Te1VLG/bGLsAyGWrqR5FfR7tbFUI7FEF2LiGA==
+validator@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Zenodo DOIs frequently use `info:eu-repo/semantics/openAccess` for `rightsURI`. Our validator should validate them.