### PR TITLE
Fix to display total members and repositories

### DIFF
--- a/app/components/bar-chart.js
+++ b/app/components/bar-chart.js
@@ -25,6 +25,10 @@ export default Component.extend({
         if (currentYear) {
           return currentYear.count;
         } else {
+          let lastYear = A(this.data).findBy('id', (new Date().getFullYear() - 1).toString());
+          if (lastYear) {
+            return lastYear.count;
+          }
           return 0;
         }
       }


### PR DESCRIPTION
## Purpose
Fix member and repository counts display on info page.

## Approach
There were no members or repositories for current year (2020). I have changed it to current year - 1, if current year is undefined.


