### PR TITLE
fix: reverse pascal casing

### DIFF
--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -200,7 +200,7 @@ export default Component.extend({
     this.set('relationTypes', relationTypeList);
   },
   selectRelatedIdentifierType(relatedIdentifierType) {
-    this.fragment.set('relatedIdentifierType', pascalCase(relatedIdentifierType));
+    this.fragment.set('relatedIdentifierType', relatedIdentifierType);
     this.set('relatedIdentifierTypes', relatedIdentifierTypeList);
   },
   selectResourceTypeGeneral(resourceTypeGeneral) {

--- a/app/templates/components/doi-related-identifier.hbs
+++ b/app/templates/components/doi-related-identifier.hbs
@@ -18,7 +18,6 @@
 <div class="power-select-fragment" disabled={{this.controlledIdentifierType}} data-test-related-identifier-type>
   {{#form.element
     controlType="power-select"
-    id="related-identifier-type"
     value=fragment.relatedIdentifierType
     helpText="The type of the Related Identifier."
     options=relatedIdentifierTypeList


### PR DESCRIPTION
## Purpose
Pascal casing is generating error on selection

closes: https://github.com/datacite/bracco/issues/415

## Approach

reverse part of: https://github.com/datacite/bracco/commit/56a3460cc9bd285a9e8f8f2dfd1a783f7f0d56a6

<!--- _How does this change address the problem?_ -->



## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve  -->

## Status
- [x] Ready for Review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
