### PR TITLE
feat: force all the dois updated with the form to become schema 4

### DIFF
--- a/app/controllers/dois/show/edit.js
+++ b/app/controllers/dois/show/edit.js
@@ -29,7 +29,7 @@ export default Controller.extend({
       }
 
       // schema-version will be determined by API
-      doi.set('schemaVersion', null);
+      doi.set('schemaVersion', "http://datacite.org/schema/kernel-4");
 
       // track use of the form
       doi.set('source', 'fabricaForm');

--- a/app/controllers/dois/show/edit.js
+++ b/app/controllers/dois/show/edit.js
@@ -29,7 +29,7 @@ export default Controller.extend({
       }
 
       // schema-version will be determined by API
-      doi.set('schemaVersion', "http://datacite.org/schema/kernel-4");
+      doi.set('schemaVersion', 'http://datacite.org/schema/kernel-4');
 
       // track use of the form
       doi.set('source', 'fabricaForm');

--- a/app/routes/dois/show/edit.js
+++ b/app/routes/dois/show/edit.js
@@ -8,6 +8,9 @@ export default Route.extend({
   model() {
     let self = this;
     return this.store.findRecord('doi', this.modelFor('dois/show').get('id'), { include: 'client' }).then(function(doi) {
+      if (!doi.schemaVersion.endsWith('kernel-4')) {
+        self.get('flashMessages').warning('Using the Form would update this DOI to the lasest schema version.');
+      }
       return doi;
     }).catch(function(reason) {
       console.debug(reason);

--- a/app/serializers/doi.js
+++ b/app/serializers/doi.js
@@ -35,7 +35,7 @@ export default ApplicationSerializer.extend({
     // rightsList: { serialize: false },
     // geoLocations: { serialize: false },
     // fundingReferences: { serialize: false },
-    schemaVersion: { serialize: false },
+    // schemaVersion: { serialize: false },
 
     // don't send back these attributes, as they are managed by the API
     prefix: { serialize: false },

--- a/recordings/Acceptance-client_admin-doi_1416311633/update-draft-doi_1508057167/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/update-draft-doi_1508057167/recording.har
@@ -258,11 +258,11 @@
         }
       },
       {
-        "_id": "c496216b5c73db1904c03cb931b97b60",
+        "_id": "5de295337d591346687bcd19bf074f09",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 892,
+          "bodySize": 946,
           "cookies": [],
           "headers": [
             {
@@ -280,17 +280,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"attributes\":{\"doi\":\"10.80225/9fxk-aa96\",\"confirmDoi\":null,\"url\":\"https://support.datacite.org/docs/doi-states\",\"creators\":[{\"name\":\"\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"name\":\"\",\"contributorType\":\"Other\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"landingPage\":null,\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"edit\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"attributes\":{\"doi\":\"10.80225/9fxk-aa96\",\"confirmDoi\":null,\"url\":\"https://support.datacite.org/docs/doi-states\",\"creators\":[{\"name\":\"\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"name\":\"\",\"contributorType\":\"Other\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"landingPage\":null,\"xml\":null,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"edit\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois/10.80225%2F9fxk-aa96"
         },
         "response": {
-          "bodySize": 2410,
+          "bodySize": 2485,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 2410,
-            "text": "{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.80225/9fxk-aa96\",\"prefix\":\"10.80225\",\"suffix\":\"9fxk-aa96\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[],\"contributorType\":\"Other\"}],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuODAyMjUvOUZYSy1BQTk2PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIi8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8Y29udHJpYnV0b3JzPgogICAgPGNvbnRyaWJ1dG9yIGNvbnRyaWJ1dG9yVHlwZT0iT3RoZXIiPgogICAgICA8Y29udHJpYnV0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCIvPgogICAgPC9jb250cmlidXRvcj4KICA8L2NvbnRyaWJ1dG9ycz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":\"https://support.datacite.org/docs/doi-states\",\"contentUrl\":null,\"metadataVersion\":2,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-03-25T05:46:18.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:15.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "size": 2485,
+            "text": "{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.80225/9fxk-aa96\",\"prefix\":\"10.80225\",\"suffix\":\"9fxk-aa96\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[],\"contributorType\":\"Other\"}],\"dates\":[],\"language\":null,\"types\":{\"schemaOrg\":\"CreativeWork\",\"citeproc\":\"article\",\"bibtex\":\"misc\",\"ris\":\"GEN\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuODAyMjUvOUZYSy1BQTk2PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIi8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8Y29udHJpYnV0b3JzPgogICAgPGNvbnRyaWJ1dG9yIGNvbnRyaWJ1dG9yVHlwZT0iT3RoZXIiPgogICAgICA8Y29udHJpYnV0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCIvPgogICAgPC9jb250cmlidXRvcj4KICA8L2NvbnRyaWJ1dG9ycz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":\"https://support.datacite.org/docs/doi-states\",\"contentUrl\":null,\"metadataVersion\":2,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-03-25T05:46:18.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:38:48.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.80225/9fxk-aa96\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -309,8 +309,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-05-25T17:15:15.577Z",
-        "time": 411,
+        "startedDateTime": "2020-08-24T08:38:48.176Z",
+        "time": 311,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 411
+          "wait": 311
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-alternate-identfier_2444407433/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-alternate-identfier_2444407433/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "739d6ed95df7be1fa0246b1584886c65",
+        "_id": "8cbba0a8dcaccb418f91118d3b01e36e",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 656,
+          "bodySize": 677,
           "cookies": [],
           "headers": [
             {
@@ -552,7 +552,7 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/9k5z-p124\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/9k5z-p124\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
@@ -562,7 +562,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1979,
-            "text": "{\"data\":{\"id\":\"10.0330/9k5z-p124\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/9k5z-p124\",\"prefix\":\"10.0330\",\"suffix\":\"9k5z-p124\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC85SzVaLVAxMjQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:13.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:13.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/9k5z-p124\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "text": "{\"data\":{\"id\":\"10.0330/9k5z-p124\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/9k5z-p124\",\"prefix\":\"10.0330\",\"suffix\":\"9k5z-p124\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC85SzVaLVAxMjQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:57.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:57.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/9k5z-p124\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:15:13.339Z",
-        "time": 435,
+        "startedDateTime": "2020-08-24T08:57:57.634Z",
+        "time": 189,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 435
+          "wait": 189
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-contributor_847131258/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-contributor_847131258/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "3489fb3020e0860076cc8b0099386d26",
+        "_id": "7d8967cc2e8b5ac632644ef2d10e8333",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 954,
+          "bodySize": 975,
           "cookies": [],
           "headers": [
             {
@@ -552,7 +552,7 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/6xhy-be04\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"name\":null,\"contributorType\":\"DataCollector\",\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[{\"nameIdentifier\":null,\"nameIdentifierScheme\":null,\"schemeUri\":null}],\"affiliation\":[{\"name\":null,\"affiliationIdentifier\":null,\"affiliationIdentifierScheme\":null,\"schemeUri\":null}]}],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/6xhy-be04\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"name\":null,\"contributorType\":\"DataCollector\",\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[{\"nameIdentifier\":null,\"nameIdentifierScheme\":null,\"schemeUri\":null}],\"affiliation\":[{\"name\":null,\"affiliationIdentifier\":null,\"affiliationIdentifierScheme\":null,\"schemeUri\":null}]}],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
@@ -562,7 +562,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2463,
-            "text": "{\"data\":{\"id\":\"10.0330/6xhy-be04\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/6xhy-be04\",\"prefix\":\"10.0330\",\"suffix\":\"6xhy-be04\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"nameType\":null,\"nameIdentifiers\":[{\"nameIdentifier\":null,\"nameIdentifierScheme\":null,\"schemeUri\":null}],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[],\"contributorType\":\"DataCollector\"}],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC82WEhZLUJFMDQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8Y29udHJpYnV0b3JzPgogICAgPGNvbnRyaWJ1dG9yIGNvbnRyaWJ1dG9yVHlwZT0iRGF0YUNvbGxlY3RvciI+CiAgICAgIDxjb250cmlidXRvck5hbWUvPgogICAgICA8bmFtZUlkZW50aWZpZXIgbmFtZUlkZW50aWZpZXJTY2hlbWU9IiIgc2NoZW1lVVJJPSIiLz4KICAgICAgPGFmZmlsaWF0aW9uLz4KICAgIDwvY29udHJpYnV0b3I+CiAgPC9jb250cmlidXRvcnM+CiAgPHNpemVzLz4KICA8Zm9ybWF0cy8+CiAgPHZlcnNpb24vPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:03.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:03.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/6xhy-be04\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "text": "{\"data\":{\"id\":\"10.0330/6xhy-be04\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/6xhy-be04\",\"prefix\":\"10.0330\",\"suffix\":\"6xhy-be04\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[{\"nameType\":null,\"nameIdentifiers\":[{\"nameIdentifier\":null,\"nameIdentifierScheme\":null,\"schemeUri\":null}],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[],\"contributorType\":\"DataCollector\"}],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC82WEhZLUJFMDQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8Y29udHJpYnV0b3JzPgogICAgPGNvbnRyaWJ1dG9yIGNvbnRyaWJ1dG9yVHlwZT0iRGF0YUNvbGxlY3RvciI+CiAgICAgIDxjb250cmlidXRvck5hbWUvPgogICAgICA8bmFtZUlkZW50aWZpZXIgbmFtZUlkZW50aWZpZXJTY2hlbWU9IiIgc2NoZW1lVVJJPSIiLz4KICAgICAgPGFmZmlsaWF0aW9uLz4KICAgIDwvY29udHJpYnV0b3I+CiAgPC9jb250cmlidXRvcnM+CiAgPHNpemVzLz4KICA8Zm9ybWF0cy8+CiAgPHZlcnNpb24vPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:56.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:56.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/6xhy-be04\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:15:03.100Z",
-        "time": 386,
+        "startedDateTime": "2020-08-24T08:57:56.136Z",
+        "time": 208,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 386
+          "wait": 208
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-format_2886218466/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-format_2886218466/recording.har
@@ -530,70 +530,6 @@
         }
       },
       {
-        "_id": "812bad2a241e4eab92bc95a0cbd498a1",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 656,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/vnd.api+json;charset=utf-8"
-            },
-            {
-              "name": "accept",
-              "value": "application/vnd.api+json"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/vnd.api+json;charset=utf-8",
-            "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/x3ye-xt06\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
-          },
-          "queryString": [],
-          "url": "https://api.stage.datacite.org/dois"
-        },
-        "response": {
-          "bodySize": 1979,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1979,
-            "text": "{\"data\":{\"id\":\"10.0330/x3ye-xt06\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/x3ye-xt06\",\"prefix\":\"10.0330\",\"suffix\":\"x3ye-xt06\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9YM1lFLVhUMDY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:07.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:07.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/x3ye-xt06\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "max-age=0, private, must-revalidate"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            }
-          ],
-          "headersSize": 101,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2020-05-25T17:15:07.314Z",
-        "time": 652,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 652
-        }
-      },
-      {
         "_id": "f6d745d112d6f374b02a6daa415b2ae7",
         "_order": 2,
         "cache": {},
@@ -665,6 +601,70 @@
           "send": 0,
           "ssl": -1,
           "wait": 122
+        }
+      },
+      {
+        "_id": "d9e37488af70962c2889efc1ba1a00ef",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 683,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/vnd.api+json;charset=utf-8"
+            },
+            {
+              "name": "accept",
+              "value": "application/vnd.api+json"
+            }
+          ],
+          "headersSize": 781,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/vnd.api+json;charset=utf-8",
+            "params": [],
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/x3ye-xt06\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[\"json\"],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.stage.datacite.org/dois"
+        },
+        "response": {
+          "bodySize": 2033,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2033,
+            "text": "{\"data\":{\"id\":\"10.0330/x3ye-xt06\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/x3ye-xt06\",\"prefix\":\"10.0330\",\"suffix\":\"x3ye-xt06\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[\"json\"],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9YM1lFLVhUMDY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzPgogICAgPGZvcm1hdD5qc29uPC9mb3JtYXQ+CiAgPC9mb3JtYXRzPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T09:04:22.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T09:04:22.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/x3ye-xt06\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            }
+          ],
+          "headersSize": 101,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2020-08-24T09:04:22.639Z",
+        "time": 218,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 218
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-geoLocationPlace_3330462944/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-geoLocationPlace_3330462944/recording.har
@@ -392,70 +392,6 @@
         }
       },
       {
-        "_id": "9bc03e6e66cf5cfd404d668d437f2d66",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 705,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/vnd.api+json;charset=utf-8"
-            },
-            {
-              "name": "accept",
-              "value": "application/vnd.api+json"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/vnd.api+json;charset=utf-8",
-            "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/5h4m-pw34\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[{\"geoLocationPlace\":\"Amsterdam, Novoravis hotel\"}],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
-          },
-          "queryString": [],
-          "url": "https://api.stage.datacite.org/dois"
-        },
-        "response": {
-          "bodySize": 2216,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 2216,
-            "text": "{\"data\":{\"id\":\"10.0330/5h4m-pw34\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/5h4m-pw34\",\"prefix\":\"10.0330\",\"suffix\":\"5h4m-pw34\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[{\"geoLocationPlace\":\"Amsterdam, Novoravis hotel\"}],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC81SDRNLVBXMzQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CiAgPGdlb0xvY2F0aW9ucz4KICAgIDxnZW9Mb2NhdGlvbj4KICAgICAgPGdlb0xvY2F0aW9uUGxhY2U+QW1zdGVyZGFtLCBOb3ZvcmF2aXMgaG90ZWw8L2dlb0xvY2F0aW9uUGxhY2U+CiAgICA8L2dlb0xvY2F0aW9uPgogIDwvZ2VvTG9jYXRpb25zPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:14:59.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:14:59.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/5h4m-pw34\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "max-age=0, private, must-revalidate"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            }
-          ],
-          "headersSize": 101,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2020-05-25T17:14:59.231Z",
-        "time": 581,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 581
-        }
-      },
-      {
         "_id": "3595b83e4685cc3cbc3de4c85e545782",
         "_order": 1,
         "cache": {},
@@ -665,6 +601,70 @@
           "send": 0,
           "ssl": -1,
           "wait": 124
+        }
+      },
+      {
+        "_id": "f31bf9cd1d88e1fded47c34bf6af589f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 726,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/vnd.api+json;charset=utf-8"
+            },
+            {
+              "name": "accept",
+              "value": "application/vnd.api+json"
+            }
+          ],
+          "headersSize": 781,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/vnd.api+json;charset=utf-8",
+            "params": [],
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/5h4m-pw34\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[{\"geoLocationPlace\":\"Amsterdam, Novoravis hotel\"}],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.stage.datacite.org/dois"
+        },
+        "response": {
+          "bodySize": 2216,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2216,
+            "text": "{\"data\":{\"id\":\"10.0330/5h4m-pw34\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/5h4m-pw34\",\"prefix\":\"10.0330\",\"suffix\":\"5h4m-pw34\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[{\"geoLocationPlace\":\"Amsterdam, Novoravis hotel\"}],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC81SDRNLVBXMzQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CiAgPGdlb0xvY2F0aW9ucz4KICAgIDxnZW9Mb2NhdGlvbj4KICAgICAgPGdlb0xvY2F0aW9uUGxhY2U+QW1zdGVyZGFtLCBOb3ZvcmF2aXMgaG90ZWw8L2dlb0xvY2F0aW9uUGxhY2U+CiAgICA8L2dlb0xvY2F0aW9uPgogIDwvZ2VvTG9jYXRpb25zPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:58:39.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:58:39.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/5h4m-pw34\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            }
+          ],
+          "headersSize": 101,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2020-08-24T08:58:38.970Z",
+        "time": 202,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 202
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-related-identifier_2083658827/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-related-identifier_2083658827/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "0c76b95b57113799eae71b50bf01c1d2",
+        "_id": "72909ed637540849c4bb8f6672171e3b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 870,
           "cookies": [],
           "headers": [
             {
@@ -552,7 +552,7 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/d0tr-4j67\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[{\"relatedIdentifier\":\"10.70048/rph240519\",\"relatedIdentifierType\":\"DOI\",\"relationType\":\"References\",\"relatedMetadataScheme\":null,\"schemeUri\":null,\"schemeType\":null,\"resourceTypeGeneral\":\"Text\"}],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/d0tr-4j67\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[{\"relatedIdentifier\":\"10.70048/rph240519\",\"relatedIdentifierType\":\"DOI\",\"relationType\":\"References\",\"relatedMetadataScheme\":null,\"schemeUri\":null,\"schemeType\":null,\"resourceTypeGeneral\":\"Text\"}],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
@@ -562,7 +562,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2424,
-            "text": "{\"data\":{\"id\":\"10.0330/d0tr-4j67\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/d0tr-4j67\",\"prefix\":\"10.0330\",\"suffix\":\"d0tr-4j67\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[{\"relatedIdentifier\":\"10.70048/rph240519\",\"relatedIdentifierType\":\"DOI\",\"relationType\":\"References\",\"relatedMetadataScheme\":null,\"schemeUri\":null,\"schemeType\":null,\"resourceTypeGeneral\":\"Text\"}],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9EMFRSLTRKNjc8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8cmVsYXRlZElkZW50aWZpZXJzPgogICAgPHJlbGF0ZWRJZGVudGlmaWVyIHJlbGF0ZWRJZGVudGlmaWVyVHlwZT0iRE9JIiByZWxhdGlvblR5cGU9IlJlZmVyZW5jZXMiIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPjEwLjcwMDQ4L3JwaDI0MDUxOTwvcmVsYXRlZElkZW50aWZpZXI+CiAgPC9yZWxhdGVkSWRlbnRpZmllcnM+CiAgPHNpemVzLz4KICA8Zm9ybWF0cy8+CiAgPHZlcnNpb24vPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:21.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:21.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/d0tr-4j67\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "text": "{\"data\":{\"id\":\"10.0330/d0tr-4j67\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/d0tr-4j67\",\"prefix\":\"10.0330\",\"suffix\":\"d0tr-4j67\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[{\"relatedIdentifier\":\"10.70048/rph240519\",\"relatedIdentifierType\":\"DOI\",\"relationType\":\"References\",\"relatedMetadataScheme\":null,\"schemeUri\":null,\"schemeType\":null,\"resourceTypeGeneral\":\"Text\"}],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9EMFRSLTRKNjc8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8cmVsYXRlZElkZW50aWZpZXJzPgogICAgPHJlbGF0ZWRJZGVudGlmaWVyIHJlbGF0ZWRJZGVudGlmaWVyVHlwZT0iRE9JIiByZWxhdGlvblR5cGU9IlJlZmVyZW5jZXMiIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPjEwLjcwMDQ4L3JwaDI0MDUxOTwvcmVsYXRlZElkZW50aWZpZXI+CiAgPC9yZWxhdGVkSWRlbnRpZmllcnM+CiAgPHNpemVzLz4KICA8Zm9ybWF0cy8+CiAgPHZlcnNpb24vPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:59.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:59.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/d0tr-4j67\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:15:21.671Z",
-        "time": 513,
+        "startedDateTime": "2020-08-24T08:57:59.296Z",
+        "time": 209,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 513
+          "wait": 209
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-resource-type-general_2212790731/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-resource-type-general_2212790731/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "1b64ecba524e48784d62f9af79efd437",
+        "_id": "f2f78b02c0657e97514dabd2bfc04559",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 695,
+          "bodySize": 716,
           "cookies": [],
           "headers": [
             {
@@ -552,17 +552,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/nj4e-vr34\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{\"resourceTypeGeneral\":\"Text\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/nj4e-vr34\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{\"resourceTypeGeneral\":\"Text\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
         },
         "response": {
-          "bodySize": 2067,
+          "bodySize": 2159,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 2067,
-            "text": "{\"data\":{\"id\":\"10.0330/nj4e-vr34\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/nj4e-vr34\",\"prefix\":\"10.0330\",\"suffix\":\"nj4e-vr34\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{\"resourceTypeGeneral\":\"Text\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9OSjRFLVZSMzQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:14:52.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:14:52.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/nj4e-vr34\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "size": 2159,
+            "text": "{\"data\":{\"id\":\"10.0330/nj4e-vr34\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/nj4e-vr34\",\"prefix\":\"10.0330\",\"suffix\":\"nj4e-vr34\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{\"schemaOrg\":\"ScholarlyArticle\",\"citeproc\":\"article-journal\",\"bibtex\":\"article\",\"ris\":\"RPRT\",\"resourceTypeGeneral\":\"Text\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9OSjRFLVZSMzQ8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:50.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:50.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/nj4e-vr34\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:14:52.213Z",
-        "time": 368,
+        "startedDateTime": "2020-08-24T08:57:50.393Z",
+        "time": 195,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 368
+          "wait": 195
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-rights_3222538706/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-rights_3222538706/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "fd3ff130d802439517d4a70f3cfe1c07",
+        "_id": "bcc478d77212ffe8674ca38678aae739",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 745,
+          "bodySize": 766,
           "cookies": [],
           "headers": [
             {
@@ -552,17 +552,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/ts0n-ae56\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[{\"rights\":\"Attribution Assurance License\",\"rightsUri\":\"http://spdx.org/licenses/AA.json\"}],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/ts0n-ae56\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[{\"rights\":\"Attribution Assurance License\",\"rightsUri\":\"http://spdx.org/licenses/AA.json\"}],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
         },
         "response": {
-          "bodySize": 2236,
+          "bodySize": 2345,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 2236,
-            "text": "{\"data\":{\"id\":\"10.0330/ts0n-ae56\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/ts0n-ae56\",\"prefix\":\"10.0330\",\"suffix\":\"ts0n-ae56\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[{\"rights\":\"Attribution Assurance License\",\"rightsUri\":\"http://spdx.org/licenses/AA.json\"}],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9UUzBOLUFFNTY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CiAgPHJpZ2h0c0xpc3Q+CiAgICA8cmlnaHRzIHJpZ2h0c1VSST0iaHR0cDovL3NwZHgub3JnL2xpY2Vuc2VzL0FBLmpzb24iPkF0dHJpYnV0aW9uIEFzc3VyYW5jZSBMaWNlbnNlPC9yaWdodHM+CiAgPC9yaWdodHNMaXN0Pgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:25.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:25.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/ts0n-ae56\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "size": 2345,
+            "text": "{\"data\":{\"id\":\"10.0330/ts0n-ae56\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/ts0n-ae56\",\"prefix\":\"10.0330\",\"suffix\":\"ts0n-ae56\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[{\"rights\":\"Attribution Assurance License\",\"rightsUri\":\"https://opensource.org/licenses/attribution\",\"rightsIdentifier\":\"aal\",\"rightsIdentifierScheme\":\"SPDX\",\"schemeUri\":\"https://spdx.org/licenses/\"}],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9UUzBOLUFFNTY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CiAgPHJpZ2h0c0xpc3Q+CiAgICA8cmlnaHRzIHJpZ2h0c1VSST0iaHR0cDovL3NwZHgub3JnL2xpY2Vuc2VzL0FBLmpzb24iPkF0dHJpYnV0aW9uIEFzc3VyYW5jZSBMaWNlbnNlPC9yaWdodHM+CiAgPC9yaWdodHNMaXN0Pgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:58:01.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:58:01.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/ts0n-ae56\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:15:24.876Z",
-        "time": 403,
+        "startedDateTime": "2020-08-24T08:58:01.271Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 403
+          "wait": 216
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-size_686014060/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-adding-size_686014060/recording.har
@@ -530,70 +530,6 @@
         }
       },
       {
-        "_id": "2b10f058cca4cffee8ed8256d714da2e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 656,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/vnd.api+json;charset=utf-8"
-            },
-            {
-              "name": "accept",
-              "value": "application/vnd.api+json"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/vnd.api+json;charset=utf-8",
-            "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/jdcr-3421\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
-          },
-          "queryString": [],
-          "url": "https://api.stage.datacite.org/dois"
-        },
-        "response": {
-          "bodySize": 1979,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1979,
-            "text": "{\"data\":{\"id\":\"10.0330/jdcr-3421\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/jdcr-3421\",\"prefix\":\"10.0330\",\"suffix\":\"jdcr-3421\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9KRENSLTM0MjE8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:15:10.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:15:10.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/jdcr-3421\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "max-age=0, private, must-revalidate"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            }
-          ],
-          "headersSize": 101,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2020-05-25T17:15:10.579Z",
-        "time": 521,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 521
-        }
-      },
-      {
         "_id": "f6d745d112d6f374b02a6daa415b2ae7",
         "_order": 2,
         "cache": {},
@@ -665,6 +601,70 @@
           "send": 0,
           "ssl": -1,
           "wait": 82
+        }
+      },
+      {
+        "_id": "235ca7c49d517259017ca0b08e038373",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 682,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/vnd.api+json;charset=utf-8"
+            },
+            {
+              "name": "accept",
+              "value": "application/vnd.api+json"
+            }
+          ],
+          "headersSize": 781,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/vnd.api+json;charset=utf-8",
+            "params": [],
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/jdcr-3421\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[\"5kb\"],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.stage.datacite.org/dois"
+        },
+        "response": {
+          "bodySize": 2024,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2024,
+            "text": "{\"data\":{\"id\":\"10.0330/jdcr-3421\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/jdcr-3421\",\"prefix\":\"10.0330\",\"suffix\":\"jdcr-3421\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[\"5kb\"],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9KRENSLTM0MjE8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c2l6ZXM+CiAgICA8c2l6ZT41a2I8L3NpemU+CiAgPC9zaXplcz4KICA8Zm9ybWF0cy8+CiAgPHZlcnNpb24vPgo8L3Jlc291cmNlPgo=\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T09:04:23.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T09:04:23.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/jdcr-3421\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            }
+          ],
+          "headersSize": 101,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2020-08-24T09:04:23.668Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-selecting-language_2341761968/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-selecting-language_2341761968/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "4e910137920e17e04fb13345309e727a",
+        "_id": "6745b588eb0f60aa671cffe6e3afa307",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 656,
+          "bodySize": 677,
           "cookies": [],
           "headers": [
             {
@@ -552,7 +552,7 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/enqf-wk42\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":\"en\",\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/enqf-wk42\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":\"en\",\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
@@ -562,7 +562,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2011,
-            "text": "{\"data\":{\"id\":\"10.0330/enqf-wk42\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/enqf-wk42\",\"prefix\":\"10.0330\",\"suffix\":\"enqf-wk42\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":\"en\",\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9FTlFGLVdLNDI8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8bGFuZ3VhZ2U+ZW48L2xhbmd1YWdlPgogIDxzaXplcy8+CiAgPGZvcm1hdHMvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-05-25T17:14:54.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-05-25T17:14:54.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/enqf-wk42\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "text": "{\"data\":{\"id\":\"10.0330/enqf-wk42\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/enqf-wk42\",\"prefix\":\"10.0330\",\"suffix\":\"enqf-wk42\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":\"en\",\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9FTlFGLVdLNDI8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8bGFuZ3VhZ2U+ZW48L2xhbmd1YWdlPgogIDxzaXplcy8+CiAgPGZvcm1hdHMvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:52.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:52.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/enqf-wk42\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-05-25T17:14:54.543Z",
-        "time": 838,
+        "startedDateTime": "2020-08-24T08:57:51.973Z",
+        "time": 203,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 838
+          "wait": 203
         }
       }
     ],

--- a/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-selecting-subject_360826678/recording.har
+++ b/recordings/Acceptance-client_admin-doi_1416311633/visiting-the-form-and-selecting-subject_360826678/recording.har
@@ -530,11 +530,11 @@
         }
       },
       {
-        "_id": "f5a1c597d9a807fa4fa756bce82e99a8",
+        "_id": "77206d3b3dafa57968857878086af96c",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 859,
+          "bodySize": 880,
           "cookies": [],
           "headers": [
             {
@@ -552,17 +552,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/hrb6-mb56\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[{\"subject\":\"FOS: Materials engineering\",\"subjectScheme\":\"Fields of Science and Technology (FOS)\",\"schemeUri\":\"http://www.oecd.org/science/inno\",\"valueUri\":\"http://www.oecd.org/science/inno/38235147.pdf\"}],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"attributes\":{\"doi\":\"10.0330/hrb6-mb56\",\"confirmDoi\":null,\"url\":null,\"creators\":[{\"name\":null,\"givenName\":null,\"familyName\":null,\"nameType\":null,\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[{\"subject\":\"FOS: Materials engineering\",\"subjectScheme\":\"Fields of Science and Technology (FOS)\",\"schemeUri\":\"http://www.oecd.org/science/inno\",\"valueUri\":\"http://www.oecd.org/science/inno/38235147.pdf\"}],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"new\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois"
         },
         "response": {
-          "bodySize": 2494,
+          "bodySize": 2388,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 2494,
-            "text": "{\"data\":{\"id\":\"10.0330/hrb6-mb56\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/hrb6-mb56\",\"prefix\":\"10.0330\",\"suffix\":\"hrb6-mb56\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[{\"subject\":\"FOS: Materials engineering\",\"subjectScheme\":\"Fields of Science and Technology (FOS)\",\"schemeUri\":\"http://www.oecd.org/science/inno\",\"valueUri\":\"http://www.oecd.org/science/inno/38235147.pdf\"}],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9IUkI2LU1CNTY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c3ViamVjdHM+CiAgICA8c3ViamVjdCBzdWJqZWN0U2NoZW1lPSJGaWVsZHMgb2YgU2NpZW5jZSBhbmQgVGVjaG5vbG9neSAoRk9TKSIgc2NoZW1lVVJJPSJodHRwOi8vd3d3Lm9lY2Qub3JnL3NjaWVuY2UvaW5ubyIgdmFsdWVVUkk9Imh0dHA6Ly93d3cub2VjZC5vcmcvc2NpZW5jZS9pbm5vLzM4MjM1MTQ3LnBkZiI+Rk9TOiBNYXRlcmlhbHMgZW5naW5lZXJpbmc8L3N1YmplY3Q+CiAgPC9zdWJqZWN0cz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-06-02T07:45:45.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-06-02T07:45:45.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/hrb6-mb56\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "size": 2388,
+            "text": "{\"data\":{\"id\":\"10.0330/hrb6-mb56\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/hrb6-mb56\",\"prefix\":\"10.0330\",\"suffix\":\"hrb6-mb56\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":null,\"nameIdentifiers\":[],\"name\":null,\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[{\"subject\":\"FOS: Materials engineering\",\"subjectScheme\":\"Fields of Science and Technology (FOS)\"}],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC9IUkI2LU1CNTY8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZS8+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzLz4KICA8cHVibGlzaGVyLz4KICA8cHVibGljYXRpb25ZZWFyLz4KICA8c3ViamVjdHM+CiAgICA8c3ViamVjdCBzdWJqZWN0U2NoZW1lPSJGaWVsZHMgb2YgU2NpZW5jZSBhbmQgVGVjaG5vbG9neSAoRk9TKSIgc2NoZW1lVVJJPSJodHRwOi8vd3d3Lm9lY2Qub3JnL3NjaWVuY2UvaW5ubyIgdmFsdWVVUkk9Imh0dHA6Ly93d3cub2VjZC5vcmcvc2NpZW5jZS9pbm5vLzM4MjM1MTQ3LnBkZiI+Rk9TOiBNYXRlcmlhbHMgZW5naW5lZXJpbmc8L3N1YmplY3Q+CiAgPC9zdWJqZWN0cz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbi8+CjwvcmVzb3VyY2U+Cg==\",\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-24T08:57:53.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T08:57:53.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/hrb6-mb56\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -581,8 +581,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2020-06-02T07:45:45.337Z",
-        "time": 246,
+        "startedDateTime": "2020-08-24T08:57:53.648Z",
+        "time": 206,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -590,7 +590,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 246
+          "wait": 206
         }
       }
     ],

--- a/recordings/Acceptance-staff_admin-doi_1134964664/update-draft-doi_1508057167/recording.har
+++ b/recordings/Acceptance-staff_admin-doi_1134964664/update-draft-doi_1508057167/recording.har
@@ -258,11 +258,11 @@
         }
       },
       {
-        "_id": "11696d2d98458e6d2245e3a1e07d721f",
+        "_id": "95985ce46f174ac40210640768cf6705",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 732,
+          "bodySize": 786,
           "cookies": [],
           "headers": [
             {
@@ -280,17 +280,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"id\":\"10.0330/3nym-s568\",\"attributes\":{\"doi\":\"10.0330/3nym-s568\",\"confirmDoi\":null,\"url\":\"http://datacite548\",\"creators\":[{\"name\":\"\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"landingPage\":null,\"xml\":null,\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"edit\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
+            "text": "{\"data\":{\"id\":\"10.0330/3nym-s568\",\"attributes\":{\"doi\":\"10.0330/3nym-s568\",\"confirmDoi\":null,\"url\":\"http://datacite473\",\"creators\":[{\"name\":\"\",\"givenName\":null,\"familyName\":null,\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"alternateIdentifiers\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"landingPage\":null,\"xml\":null,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"state\":\"draft\",\"reason\":null,\"event\":null,\"mode\":\"edit\"},\"relationships\":{\"client\":{\"data\":{\"type\":\"repositories\",\"id\":\"datacite.test\"}}},\"type\":\"dois\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/dois/10.0330%2F3nym-s568"
         },
         "response": {
-          "bodySize": 2056,
+          "bodySize": 2131,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 2056,
-            "text": "{\"data\":{\"id\":\"10.0330/3nym-s568\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/3nym-s568\",\"prefix\":\"10.0330\",\"suffix\":\"3nym-s568\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC8zTllNLVM1Njg8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiLz4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXMvPgogIDxwdWJsaXNoZXIvPgogIDxwdWJsaWNhdGlvblllYXIvPgogIDxzaXplcy8+CiAgPGZvcm1hdHMvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K\",\"url\":\"http://datacite548\",\"contentUrl\":null,\"metadataVersion\":1,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-04-23T07:40:07.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-06-02T10:15:22.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/3nym-s568\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
+            "size": 2131,
+            "text": "{\"data\":{\"id\":\"10.0330/3nym-s568\",\"type\":\"dois\",\"attributes\":{\"doi\":\"10.0330/3nym-s568\",\"prefix\":\"10.0330\",\"suffix\":\"3nym-s568\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[{\"nameType\":\"Personal\",\"nameIdentifiers\":[],\"name\":\"\",\"givenName\":null,\"familyName\":null,\"affiliation\":[]}],\"titles\":[],\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{\"schemaOrg\":\"CreativeWork\",\"citeproc\":\"article\",\"bibtex\":\"misc\",\"ris\":\"GEN\"},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":\"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMDMzMC8zTllNLVM1Njg8L2lkZW50aWZpZXI+CiAgPGNyZWF0b3JzPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiLz4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXMvPgogIDxwdWJsaXNoZXIvPgogIDxwdWJsaWNhdGlvblllYXIvPgogIDxzaXplcy8+CiAgPGZvcm1hdHMvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K\",\"url\":\"http://datacite473\",\"contentUrl\":null,\"metadataVersion\":1,\"schemaVersion\":\"http://datacite.org/schema/kernel-4\",\"source\":\"fabricaForm\",\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-04-23T07:40:07.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-24T09:21:46.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"datacite.test\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"10.0330/3nym-s568\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -309,8 +309,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-02T10:15:22.547Z",
-        "time": 315,
+        "startedDateTime": "2020-08-24T09:21:46.478Z",
+        "time": 280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 315
+          "wait": 280
         }
       }
     ],

--- a/recordings/Acceptance-staff_admin-provider_521206357/updating-consortium-DC_3494094721/recording.har
+++ b/recordings/Acceptance-staff_admin-provider_521206357/updating-consortium-DC_3494094721/recording.har
@@ -76,7 +76,7 @@
         }
       },
       {
-        "_id": "8507e0ed14bf02559fd0ef9cd832c75a",
+        "_id": "ec224105cbd6b724f186c509b7a8c046",
         "_order": 0,
         "cache": {},
         "request": {
@@ -98,17 +98,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"id\":\"dc\",\"attributes\":{\"meta\":{\"repositoryCount\":0,\"consortiumOrganizationCount\":21},\"name\":\"DataCite Consortium\",\"displayName\":\"DataCite Consortium\",\"symbol\":\"DC\",\"globusUuid\":null,\"description\":null,\"region\":\"EMEA\",\"country\":\"DE\",\"memberType\":\"consortium\",\"organizationType\":\"serviceProvider\",\"focusArea\":\"general\",\"logoUrl\":null,\"systemEmail\":\"info@datacite.org\",\"groupEmail\":\"info@datacite.org\",\"website\":\"https://datacite.org\",\"isActive\":true,\"passwordInput\":null,\"nonProfitStatus\":\"non-profit\",\"hasPassword\":true,\"keepPassword\":true,\"rorId\":\"https://ror.org/04wxnsj81\",\"salesforceId\":null,\"twitterHandle\":\"@datacite510\",\"billingInformation\":{\"city\":\"\"},\"technicalContact\":{},\"secondaryTechnicalContact\":{},\"billingContact\":{},\"secondaryBillingContact\":{},\"secondaryServiceContact\":{},\"serviceContact\":{\"email\":\"info@datacite.org\"},\"votingContact\":{\"email\":\"info@datacite.org\",\"givenName\":\"John\",\"familyName\":\"Doe\"},\"joined\":null,\"created\":\"2019-08-06T07:04:35.000Z\",\"updated\":\"2020-05-19T10:38:30.000Z\"},\"type\":\"providers\"}}"
+            "text": "{\"data\":{\"id\":\"dc\",\"attributes\":{\"meta\":{\"repositoryCount\":0,\"consortiumOrganizationCount\":21},\"name\":\"DataCite Consortium\",\"displayName\":\"DataCite Consortium\",\"symbol\":\"DC\",\"globusUuid\":null,\"description\":null,\"region\":\"EMEA\",\"country\":\"DE\",\"memberType\":\"consortium\",\"organizationType\":\"serviceProvider\",\"focusArea\":\"general\",\"logoUrl\":null,\"systemEmail\":\"info@datacite.org\",\"groupEmail\":\"info@datacite.org\",\"website\":\"https://datacite.org\",\"isActive\":true,\"passwordInput\":null,\"nonProfitStatus\":\"non-profit\",\"hasPassword\":true,\"keepPassword\":true,\"rorId\":\"https://ror.org/04wxnsj81\",\"salesforceId\":null,\"twitterHandle\":\"@datacite634\",\"billingInformation\":{\"city\":\"\"},\"technicalContact\":{},\"secondaryTechnicalContact\":{},\"billingContact\":{},\"secondaryBillingContact\":{},\"secondaryServiceContact\":{},\"serviceContact\":{\"email\":\"info@datacite.org\"},\"votingContact\":{\"email\":\"info@datacite.org\",\"givenName\":\"John\",\"familyName\":\"Doe\"},\"joined\":null,\"created\":\"2019-08-06T07:04:35.000Z\",\"updated\":\"2020-05-19T10:38:30.000Z\"},\"type\":\"providers\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/providers/dc"
         },
         "response": {
-          "bodySize": 1753,
+          "bodySize": 1786,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1753,
-            "text": "{\"data\":{\"id\":\"dc\",\"type\":\"providers\",\"attributes\":{\"name\":\"DataCite Consortium\",\"displayName\":\"DataCite Consortium\",\"symbol\":\"DC\",\"website\":\"https://datacite.org\",\"systemEmail\":\"info@datacite.org\",\"groupEmail\":\"info@datacite.org\",\"globusUuid\":null,\"description\":null,\"region\":\"EMEA\",\"country\":\"DE\",\"logoUrl\":null,\"memberType\":\"consortium\",\"organizationType\":\"serviceProvider\",\"focusArea\":\"general\",\"nonProfitStatus\":\"non-profit\",\"isActive\":true,\"hasPassword\":true,\"joined\":null,\"twitterHandle\":\"@datacite510\",\"billingInformation\":{\"city\":\"\"},\"rorId\":\"https://ror.org/04wxnsj81\",\"salesforceId\":null,\"technicalContact\":{},\"secondaryTechnicalContact\":{},\"billingContact\":{},\"secondaryBillingContact\":{},\"serviceContact\":{\"email\":\"info@datacite.org\"},\"secondaryServiceContact\":{},\"votingContact\":{\"email\":\"info@datacite.org\",\"givenName\":\"John\",\"familyName\":\"Doe\"},\"created\":\"2019-08-06T07:04:35.000Z\",\"updated\":\"2020-06-02T10:15:27.000Z\"},\"relationships\":{\"clients\":{\"data\":[]},\"prefixes\":{\"data\":[]},\"consortiumOrganizations\":{\"data\":[{\"id\":\"demo\",\"type\":\"providers\"},{\"id\":\"datacite\",\"type\":\"providers\"},{\"id\":\"sml\",\"type\":\"providers\"},{\"id\":\"bibtag\",\"type\":\"providers\"},{\"id\":\"workshop\",\"type\":\"providers\"},{\"id\":\"bka\",\"type\":\"providers\"},{\"id\":\"testmary\",\"type\":\"providers\"},{\"id\":\"rphco\",\"type\":\"providers\"},{\"id\":\"testaa\",\"type\":\"providers\"},{\"id\":\"marytest\",\"type\":\"providers\"},{\"id\":\"abcde\",\"type\":\"providers\"},{\"id\":\"uuaa\",\"type\":\"providers\"},{\"id\":\"uuuu\",\"type\":\"providers\"},{\"id\":\"ydtr\",\"type\":\"providers\"},{\"id\":\"vpmj\",\"type\":\"providers\"},{\"id\":\"clyy\",\"type\":\"providers\"},{\"id\":\"mgxi\",\"type\":\"providers\"},{\"id\":\"epow\",\"type\":\"providers\"},{\"id\":\"cnsrtrg\",\"type\":\"providers\"},{\"id\":\"moia\",\"type\":\"providers\"},{\"id\":\"xwpb\",\"type\":\"providers\"}]}}}}"
+            "size": 1786,
+            "text": "{\"data\":{\"id\":\"dc\",\"type\":\"providers\",\"attributes\":{\"name\":\"DataCite Consortium\",\"displayName\":\"DataCite Consortium\",\"symbol\":\"DC\",\"website\":\"https://datacite.org\",\"systemEmail\":\"info@datacite.org\",\"groupEmail\":\"info@datacite.org\",\"globusUuid\":null,\"description\":null,\"region\":\"EMEA\",\"country\":\"DE\",\"logoUrl\":null,\"memberType\":\"consortium\",\"organizationType\":\"serviceProvider\",\"focusArea\":\"general\",\"nonProfitStatus\":\"non-profit\",\"isActive\":true,\"hasPassword\":true,\"joined\":null,\"twitterHandle\":\"@datacite634\",\"billingInformation\":{\"city\":\"\"},\"rorId\":\"https://ror.org/04wxnsj81\",\"salesforceId\":null,\"technicalContact\":{},\"secondaryTechnicalContact\":{},\"billingContact\":{},\"secondaryBillingContact\":{},\"serviceContact\":{\"email\":\"info@datacite.org\"},\"secondaryServiceContact\":{},\"votingContact\":{\"email\":\"info@datacite.org\",\"givenName\":\"John\",\"familyName\":\"Doe\"},\"created\":\"2019-08-06T07:04:35.000Z\",\"updated\":\"2020-08-24T09:21:49.000Z\"},\"relationships\":{\"clients\":{\"data\":[]},\"prefixes\":{\"data\":[]},\"consortiumOrganizations\":{\"data\":[{\"id\":\"demo\",\"type\":\"providers\"},{\"id\":\"datacite\",\"type\":\"providers\"},{\"id\":\"sml\",\"type\":\"providers\"},{\"id\":\"bibtag\",\"type\":\"providers\"},{\"id\":\"workshop\",\"type\":\"providers\"},{\"id\":\"bka\",\"type\":\"providers\"},{\"id\":\"testmary\",\"type\":\"providers\"},{\"id\":\"rphco\",\"type\":\"providers\"},{\"id\":\"testaa\",\"type\":\"providers\"},{\"id\":\"marytest\",\"type\":\"providers\"},{\"id\":\"abcde\",\"type\":\"providers\"},{\"id\":\"uuaa\",\"type\":\"providers\"},{\"id\":\"uuuu\",\"type\":\"providers\"},{\"id\":\"ydtr\",\"type\":\"providers\"},{\"id\":\"vpmj\",\"type\":\"providers\"},{\"id\":\"clyy\",\"type\":\"providers\"},{\"id\":\"mgxi\",\"type\":\"providers\"},{\"id\":\"epow\",\"type\":\"providers\"},{\"id\":\"cnsrtrg\",\"type\":\"providers\"},{\"id\":\"moia\",\"type\":\"providers\"},{\"id\":\"xwpb\",\"type\":\"providers\"},{\"id\":\"qhen\",\"type\":\"providers\"}]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-02T10:15:27.306Z",
-        "time": 144,
+        "startedDateTime": "2020-08-24T09:21:49.783Z",
+        "time": 146,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,7 +136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 144
+          "wait": 146
         }
       }
     ],

--- a/recordings/Acceptance-staff_admin-repository_4125372844/update-repository-description_3754013706/recording.har
+++ b/recordings/Acceptance-staff_admin-repository_4125372844/update-repository-description_3754013706/recording.har
@@ -135,11 +135,11 @@
         }
       },
       {
-        "_id": "a63a68e89234858db57cf8d9877b8f10",
+        "_id": "8037c12fbb02fd59c48c99f05c1d2da8",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 744,
+          "bodySize": 745,
           "cookies": [],
           "headers": [
             {
@@ -157,17 +157,17 @@
           "postData": {
             "mimeType": "application/vnd.api+json;charset=utf-8",
             "params": [],
-            "text": "{\"data\":{\"id\":\"datacite.test\",\"attributes\":{\"meta\":{\"doiCount\":35,\"prefixCount\":2},\"name\":\"DataCite Test Repository\",\"alternateName\":null,\"symbol\":\"DATACITE.TEST\",\"globusUuid\":null,\"re3data\":null,\"domains\":\"*\",\"systemEmail\":\"mfenner@datacite.org\",\"salesforceId\":null,\"year\":2017,\"description\":\"datacite30\",\"language\":[],\"certificate\":[],\"serviceContact\":{},\"issn\":{\"issnl\":null,\"electronic\":null,\"print\":null},\"url\":null,\"clientType\":\"repository\",\"repositoryType\":[],\"software\":null,\"isActive\":true,\"passwordInput\":null,\"hasPassword\":true,\"keepPassword\":true,\"created\":\"2017-07-13T15:15:33.000Z\",\"updated\":\"2020-05-19T10:38:38.000Z\",\"mode\":null},\"relationships\":{\"provider\":{\"data\":{\"type\":\"providers\",\"id\":\"datacite\"}}},\"type\":\"repositories\"}}"
+            "text": "{\"data\":{\"id\":\"datacite.test\",\"attributes\":{\"meta\":{\"doiCount\":35,\"prefixCount\":2},\"name\":\"DataCite Test Repository\",\"alternateName\":null,\"symbol\":\"DATACITE.TEST\",\"globusUuid\":null,\"re3data\":null,\"domains\":\"*\",\"systemEmail\":\"mfenner@datacite.org\",\"salesforceId\":null,\"year\":2017,\"description\":\"datacite548\",\"language\":[],\"certificate\":[],\"serviceContact\":{},\"issn\":{\"issnl\":null,\"electronic\":null,\"print\":null},\"url\":null,\"clientType\":\"repository\",\"repositoryType\":[],\"software\":null,\"isActive\":true,\"passwordInput\":null,\"hasPassword\":true,\"keepPassword\":true,\"created\":\"2017-07-13T15:15:33.000Z\",\"updated\":\"2020-05-19T10:38:38.000Z\",\"mode\":null},\"relationships\":{\"provider\":{\"data\":{\"type\":\"providers\",\"id\":\"datacite\"}}},\"type\":\"repositories\"}}"
           },
           "queryString": [],
           "url": "https://api.stage.datacite.org/repositories/datacite.test"
         },
         "response": {
-          "bodySize": 702,
+          "bodySize": 703,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 702,
-            "text": "{\"data\":{\"id\":\"datacite.test\",\"type\":\"repositories\",\"attributes\":{\"name\":\"DataCite Test Repository\",\"symbol\":\"DATACITE.TEST\",\"re3data\":null,\"opendoar\":null,\"year\":2017,\"systemEmail\":\"mfenner@datacite.org\",\"globusUuid\":null,\"alternateName\":null,\"description\":\"datacite30\",\"clientType\":\"repository\",\"repositoryType\":[],\"language\":[],\"certificate\":[],\"domains\":\"*\",\"issn\":{},\"url\":null,\"salesforceId\":null,\"created\":\"2017-07-13T15:15:33.000Z\",\"updated\":\"2020-06-02T10:15:38.000Z\",\"isActive\":true,\"hasPassword\":true,\"serviceContact\":{}},\"relationships\":{\"provider\":{\"data\":{\"id\":\"datacite\",\"type\":\"providers\"}},\"prefixes\":{\"data\":[{\"id\":\"10.0330\",\"type\":\"prefixes\"},{\"id\":\"10.80225\",\"type\":\"prefixes\"}]}}}}"
+            "size": 703,
+            "text": "{\"data\":{\"id\":\"datacite.test\",\"type\":\"repositories\",\"attributes\":{\"name\":\"DataCite Test Repository\",\"symbol\":\"DATACITE.TEST\",\"re3data\":null,\"opendoar\":null,\"year\":2017,\"systemEmail\":\"mfenner@datacite.org\",\"globusUuid\":null,\"alternateName\":null,\"description\":\"datacite548\",\"clientType\":\"repository\",\"repositoryType\":[],\"language\":[],\"certificate\":[],\"domains\":\"*\",\"issn\":{},\"url\":null,\"salesforceId\":null,\"created\":\"2017-07-13T15:15:33.000Z\",\"updated\":\"2020-08-24T09:21:58.000Z\",\"isActive\":true,\"hasPassword\":true,\"serviceContact\":{}},\"relationships\":{\"provider\":{\"data\":{\"id\":\"datacite\",\"type\":\"providers\"}},\"prefixes\":{\"data\":[{\"id\":\"10.0330\",\"type\":\"prefixes\"},{\"id\":\"10.80225\",\"type\":\"prefixes\"}]}}}}"
           },
           "cookies": [],
           "headers": [
@@ -186,8 +186,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-02T10:15:38.052Z",
-        "time": 153,
+        "startedDateTime": "2020-08-24T09:21:58.656Z",
+        "time": 151,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -195,7 +195,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 153
+          "wait": 151
         }
       }
     ],


### PR DESCRIPTION
## Purpose
Forces all DOIs updated in the form to become schema 4. 

closes: https://github.com/datacite/bracco/issues/447

## Approach

All DOIs updated in the form will be transformed to schema 4. Independently of the state of the DOI (draft, registered, findable)


## Learning

Looking back at the form support messages it can be seen that the form has not support schema transformation on the past. See https://app.frontapp.com/open/msg_29opdsb from 2019 ,which is related to https://github.com/datacite/datacite/issues/654

This most likely due to the form modifying the metadata fields. The schema version is not a metadata field.


## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
