### PR TITLE
avoid validation of existing providers

### DIFF
--- a/app/validators/unique-provider-id.js
+++ b/app/validators/unique-provider-id.js
@@ -4,8 +4,8 @@ import BaseValidator from 'ember-cp-validations/validators/base';
 const UniqueProviderId = BaseValidator.extend({
   store: service(),
 
-  validate(value) {
-    if (value.length < 2) {
+  validate(value, options, model) {
+    if (value.length < 2 || !model.get('isNew')) {
       return true;
     } else {
       return this.store.query('provider', { id: value }).then((result) => {


### PR DESCRIPTION
## Purpose

Validation of provider check if the symbol is unique even when the provider is being updated. This causes an error on updating providers.

closes: https://github.com/datacite/bracco/issues/463

## Approach

Avoid validation of uniqueness for existent records.


## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
