### PR TITLE
fix: use url validator rather than regexp

### DIFF
--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -110,7 +110,7 @@ export default Component.extend({
   updateRelatedIdentifier(value) {
     const ark = /^ark:\/[0-9]{5}\/\S+$/;
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
-    const purl = /^http?:\/\/(purl\.oclc\.org\/)/;
+    const purl = {require_host: true, host_whitelist: ['purl.org', 'oclc.org']}
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
@@ -151,7 +151,7 @@ export default Component.extend({
         this.fragment.set('relatedIdentifierType', 'LSID');
         this.set('controlledIdentifierType', true);
         break;
-      case purl.test(value):
+      case isURL(value, purl):
         this.fragment.set('relatedIdentifier', value);
         this.fragment.set('relatedIdentifierType', 'PURL');
         this.set('controlledIdentifierType', true);

--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -110,7 +110,7 @@ export default Component.extend({
   updateRelatedIdentifier(value) {
     const ark = /^ark:\/[0-9]{5}\/\S+$/;
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
-    const purl = {require_host: true, host_whitelist: ['purl.org', 'oclc.org']}
+    const purl = {require_host: true, host_whitelist: [ 'purl.org', 'oclc.org' ]};
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;

--- a/app/validators/identifier-format.js
+++ b/app/validators/identifier-format.js
@@ -7,7 +7,7 @@ const IdentifierFormat = BaseValidator.extend({
   validate(value, options, model) {
     const ark = /^ark:\/[0-9]{5}\/\S+$/;
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
-    const purl = {require_host: true, host_whitelist: ['purl.org', 'oclc.org']}
+    const purl = {require_host: true, host_whitelist: [ 'purl.org', 'oclc.org' ]};
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;

--- a/app/validators/identifier-format.js
+++ b/app/validators/identifier-format.js
@@ -7,7 +7,7 @@ const IdentifierFormat = BaseValidator.extend({
   validate(value, options, model) {
     const ark = /^ark:\/[0-9]{5}\/\S+$/;
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
-    const purl = /^http?:\/\/(purl\.oclc\.org\/)/;
+    const purl = {require_host: true, host_whitelist: ['purl.org', 'oclc.org']}
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
@@ -26,7 +26,7 @@ const IdentifierFormat = BaseValidator.extend({
       case model.relatedIdentifierType == 'LSID':
         return lsid.test(value) ? true : 'Please enter a valid LSID.';
       case model.relatedIdentifierType == 'PURL':
-        return purl.test(value) ? true : 'Please enter a valid PURL.';
+        return isURL(value, purl) ? true : 'Please enter a valid PURL.';
       case model.relatedIdentifierType == 'URN':
         return urn.test(value) ? true : 'Please enter a valid URN.';
       case model.relatedIdentifierType == 'ISBN':


### PR DESCRIPTION
## Purpose

There was a mistake in the PURL validation regexp. 

closes: https://github.com/datacite/bracco/issues/464

## Approach

We change to use URL with a whitelist of host.


## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
