### PR TITLE
Match known resource types in constants used

### DIFF
--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -1,84 +1,84 @@
 /* eslint-disable no-useless-escape */
-import Component from '@ember/component';
-import { inject as service } from '@ember/service';
-import { isURL, isISBN } from 'validator';
-import { isBlank } from '@ember/utils';
-import { pascalCase } from 'pascal-case';
+import Component from "@ember/component";
+import { inject as service } from "@ember/service";
+import { isURL, isISBN } from "validator";
+import { isBlank } from "@ember/utils";
+import { pascalCase } from "pascal-case";
 
 const relationTypeList = [
-  'Cites',
-  'Is cited by',
-  'Compiles',
-  'Is compiled by',
-  'Continues',
-  'Is continued by',
-  'Describes',
-  'Is described by',
-  'Documents',
-  'Is documented by',
-  'Is derived from',
-  'Is source of',
-  'Has metadata',
-  'Is metadata for',
-  'Has part',
-  'Is part of',
-  'Is supplemented by',
-  'Is supplement to',
-  'Obsoletes',
-  'Is obsoleted by',
-  'References',
-  'Is referenced by',
-  'Requires',
-  'Is required by',
-  'Reviews',
-  'Is reviewed by',
-  'Has version',
-  'Is version of',
-  'Is new version of',
-  'Is previous version of',
-  'Is variant form of',
-  'Is original form of',
-  'Is identical to',
+  "Cites",
+  "Is cited by",
+  "Compiles",
+  "Is compiled by",
+  "Continues",
+  "Is continued by",
+  "Describes",
+  "Is described by",
+  "Documents",
+  "Is documented by",
+  "Is derived from",
+  "Is source of",
+  "Has metadata",
+  "Is metadata for",
+  "Has part",
+  "Is part of",
+  "Is supplemented by",
+  "Is supplement to",
+  "Obsoletes",
+  "Is obsoleted by",
+  "References",
+  "Is referenced by",
+  "Requires",
+  "Is required by",
+  "Reviews",
+  "Is reviewed by",
+  "Has version",
+  "Is version of",
+  "Is new version of",
+  "Is previous version of",
+  "Is variant form of",
+  "Is original form of",
+  "Is identical to",
 ];
 
 const relatedIdentifierTypeList = [
-  'ARK',
-  'arXiv',
-  'bibcode',
-  'DOI',
-  'EAN13',
-  'EISSN',
-  'Handle',
-  'IGSN',
-  'ISBN',
-  'ISSN',
-  'ISTC',
-  'LISSN',
-  'LSID',
-  'PMID',
-  'PURL',
-  'UPC',
-  'URL',
-  'URN',
-  'w3id',
+  "ARK",
+  "arXiv",
+  "bibcode",
+  "DOI",
+  "EAN13",
+  "EISSN",
+  "Handle",
+  "IGSN",
+  "ISBN",
+  "ISSN",
+  "ISTC",
+  "LISSN",
+  "LSID",
+  "PMID",
+  "PURL",
+  "UPC",
+  "URL",
+  "URN",
+  "w3id",
 ];
 
 const resourceTypeGeneralList = [
-  'Audiovisual',
-  'Collection',
-  'DataPaper',
-  'Dataset',
-  'Event',
-  'Image',
-  'Interactive resource',
-  'Model',
-  'Physical object',
-  'Service',
-  'Software',
-  'Sound',
-  'Text',
-  'Workflow',
-  'Other',
+  "Audiovisual",
+  "Collection",
+  "DataPaper",
+  "Dataset",
+  "Event",
+  "Image",
+  "InteractiveResource",
+  "Model",
+  "PhysicalObject",
+  "Service",
+  "Software",
+  "Sound",
+  "Text",
+  "Workflow",
+  "Other",
 ];
 
 export default Component.extend({
@@ -89,28 +89,37 @@ export default Component.extend({
   relatedIdentifierTypes: relatedIdentifierTypeList,
   controlledIdentifierType: false,
   isMetadataRelationType: false,
-  isMetadataRelationTypes: [ 'HasMetadata', 'IsMetadataFor' ],
+  isMetadataRelationTypes: ["HasMetadata", "IsMetadataFor"],
   resourceTypeGeneralList,
   resourceTypesGeneral: resourceTypeGeneralList,
 
   didReceiveAttrs() {
     this._super(...arguments);
 
-    if (relatedIdentifierTypeList.includes(this.fragment.get('relatedIdentifierType'))) {
-      this.set('controlledIdentifierType', true);
+    if (
+      relatedIdentifierTypeList.includes(
+        this.fragment.get("relatedIdentifierType")
+      )
+    ) {
+      this.set("controlledIdentifierType", true);
     } else {
-      this.set('controlledIdentifierType', false);
+      this.set("controlledIdentifierType", false);
     }
-    if (this.isMetadataRelationTypes.includes(this.fragment.get('relationType'))) {
-      this.set('isMetadataRelationType', true);
+    if (
+      this.isMetadataRelationTypes.includes(this.fragment.get("relationType"))
+    ) {
+      this.set("isMetadataRelationType", true);
     } else {
-      this.set('isMetadataRelationType', false);
+      this.set("isMetadataRelationType", false);
     }
   },
   updateRelatedIdentifier(value) {
     const ark = /^ark:\/[0-9]{5}\/\S+$/;
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
-    const purl = {require_host: true, host_whitelist: [ 'purl.org', 'oclc.org' ]};
+    const purl = {
+      require_host: true,
+      host_whitelist: ["purl.org", "oclc.org"],
+    };
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
@@ -118,53 +127,53 @@ export default Component.extend({
 
     switch (true) {
       case isBlank(value):
-        this.fragment.set('relatedIdentifier', null);
-        this.fragment.set('relatedIdentifierType', null);
-        this.set('controlledIdentifierType', false);
+        this.fragment.set("relatedIdentifier", null);
+        this.fragment.set("relatedIdentifierType", null);
+        this.set("controlledIdentifierType", false);
         this.selectResourceTypeGeneral(null);
-        this.fragment.set('schemeType', null);
-        this.fragment.set('relatedMetadataScheme', null);
-        this.fragment.set('relationType', null);
+        this.fragment.set("schemeType", null);
+        this.fragment.set("relatedMetadataScheme", null);
+        this.fragment.set("relationType", null);
         break;
       case ark.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'ARK');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "ARK");
+        this.set("controlledIdentifierType", true);
         break;
       case arxiv.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'arXiv');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "arXiv");
+        this.set("controlledIdentifierType", true);
         break;
       case doi.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'DOI');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "DOI");
+        this.set("controlledIdentifierType", true);
         break;
       case bibcode.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'bibcode');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "bibcode");
+        this.set("controlledIdentifierType", true);
         break;
       case lsid.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'LSID');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "LSID");
+        this.set("controlledIdentifierType", true);
         break;
       case isURL(value, purl):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'PURL');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "PURL");
+        this.set("controlledIdentifierType", true);
         break;
       case urn.test(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'URN');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "URN");
+        this.set("controlledIdentifierType", true);
         break;
       case isISBN(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'ISBN');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "ISBN");
+        this.set("controlledIdentifierType", true);
         break;
       // // EAN currently not supported https://github.com/validatorjs/validator.js/issues/797
       // case isEAN(value):
@@ -173,52 +182,52 @@ export default Component.extend({
       //   this.set('controlledIdentifierType', true);
       //   break;
       case isURL(value):
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', 'URL');
-        this.set('controlledIdentifierType', true);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", "URL");
+        this.set("controlledIdentifierType", true);
         break;
       default:
         // // Clears the relatedIdentifierType in case the user changes the relatedIdentifier after selecting it once before.
-        this.fragment.set('relatedIdentifier', value);
-        this.fragment.set('relatedIdentifierType', null);
-        this.fragment.set('relationType', null);
-        this.set('controlledIdentifierType', false);
+        this.fragment.set("relatedIdentifier", value);
+        this.fragment.set("relatedIdentifierType", null);
+        this.fragment.set("relationType", null);
+        this.set("controlledIdentifierType", false);
         break;
     }
   },
   selectRelationType(relationType) {
     if (this.isMetadataRelationTypes.includes(relationType)) {
-      this.set('isMetadataRelationType', true);
+      this.set("isMetadataRelationType", true);
     } else {
-      this.set('isMetadataRelationType', false);
-      this.fragment.set('schemeType', null);
-      this.fragment.set('relatedMetadataScheme', null);
-      this.fragment.set('resourceTypeGeneral', null);
-      this.fragment.set('schemeUri', null);
+      this.set("isMetadataRelationType", false);
+      this.fragment.set("schemeType", null);
+      this.fragment.set("relatedMetadataScheme", null);
+      this.fragment.set("resourceTypeGeneral", null);
+      this.fragment.set("schemeUri", null);
     }
-    this.fragment.set('relationType', pascalCase(relationType));
-    this.set('relationTypes', relationTypeList);
+    this.fragment.set("relationType", pascalCase(relationType));
+    this.set("relationTypes", relationTypeList);
   },
   selectRelatedIdentifierType(relatedIdentifierType) {
-    this.fragment.set('relatedIdentifierType', relatedIdentifierType);
-    this.set('relatedIdentifierTypes', relatedIdentifierTypeList);
+    this.fragment.set("relatedIdentifierType", relatedIdentifierType);
+    this.set("relatedIdentifierTypes", relatedIdentifierTypeList);
   },
   selectResourceTypeGeneral(resourceTypeGeneral) {
-    this.fragment.set('resourceTypeGeneral', pascalCase(resourceTypeGeneral));
-    this.set('resourceTypesGeneral', resourceTypeGeneralList);
+    this.fragment.set("resourceTypeGeneral", pascalCase(resourceTypeGeneral));
+    this.set("resourceTypesGeneral", resourceTypeGeneralList);
   },
   actions: {
     updateRelatedIdentifier(value) {
       this.updateRelatedIdentifier(value.trim());
     },
     updateRelatedMetadataScheme(value) {
-      this.fragment.set('relatedMetadataScheme', value);
+      this.fragment.set("relatedMetadataScheme", value);
     },
     updateSchemeURI(value) {
-      this.fragment.set('schemeUri', value);
+      this.fragment.set("schemeUri", value);
     },
     updateSchemeType(value) {
-      this.fragment.set('schemeType', value);
+      this.fragment.set("schemeType", value);
     },
     selectRelationType(relationType) {
       this.selectRelationType(relationType);
@@ -230,7 +239,7 @@ export default Component.extend({
       this.selectResourceTypeGeneral(resourceTypeGeneral);
     },
     deleteRelatedIdentifier() {
-      this.model.get('relatedIdentifiers').removeObject(this.fragment);
+      this.model.get("relatedIdentifiers").removeObject(this.fragment);
     },
   },
 });

--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -1,84 +1,84 @@
 /* eslint-disable no-useless-escape */
-import Component from "@ember/component";
-import { inject as service } from "@ember/service";
-import { isURL, isISBN } from "validator";
-import { isBlank } from "@ember/utils";
-import { pascalCase } from "pascal-case";
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { isURL, isISBN } from 'validator';
+import { isBlank } from '@ember/utils';
+import { pascalCase } from 'pascal-case';
 
 const relationTypeList = [
-  "Cites",
-  "Is cited by",
-  "Compiles",
-  "Is compiled by",
-  "Continues",
-  "Is continued by",
-  "Describes",
-  "Is described by",
-  "Documents",
-  "Is documented by",
-  "Is derived from",
-  "Is source of",
-  "Has metadata",
-  "Is metadata for",
-  "Has part",
-  "Is part of",
-  "Is supplemented by",
-  "Is supplement to",
-  "Obsoletes",
-  "Is obsoleted by",
-  "References",
-  "Is referenced by",
-  "Requires",
-  "Is required by",
-  "Reviews",
-  "Is reviewed by",
-  "Has version",
-  "Is version of",
-  "Is new version of",
-  "Is previous version of",
-  "Is variant form of",
-  "Is original form of",
-  "Is identical to",
+  'Cites',
+  'Is cited by',
+  'Compiles',
+  'Is compiled by',
+  'Continues',
+  'Is continued by',
+  'Describes',
+  'Is described by',
+  'Documents',
+  'Is documented by',
+  'Is derived from',
+  'Is source of',
+  'Has metadata',
+  'Is metadata for',
+  'Has part',
+  'Is part of',
+  'Is supplemented by',
+  'Is supplement to',
+  'Obsoletes',
+  'Is obsoleted by',
+  'References',
+  'Is referenced by',
+  'Requires',
+  'Is required by',
+  'Reviews',
+  'Is reviewed by',
+  'Has version',
+  'Is version of',
+  'Is new version of',
+  'Is previous version of',
+  'Is variant form of',
+  'Is original form of',
+  'Is identical to',
 ];
 
 const relatedIdentifierTypeList = [
-  "ARK",
-  "arXiv",
-  "bibcode",
-  "DOI",
-  "EAN13",
-  "EISSN",
-  "Handle",
-  "IGSN",
-  "ISBN",
-  "ISSN",
-  "ISTC",
-  "LISSN",
-  "LSID",
-  "PMID",
-  "PURL",
-  "UPC",
-  "URL",
-  "URN",
-  "w3id",
+  'ARK',
+  'arXiv',
+  'bibcode',
+  'DOI',
+  'EAN13',
+  'EISSN',
+  'Handle',
+  'IGSN',
+  'ISBN',
+  'ISSN',
+  'ISTC',
+  'LISSN',
+  'LSID',
+  'PMID',
+  'PURL',
+  'UPC',
+  'URL',
+  'URN',
+  'w3id',
 ];
 
 const resourceTypeGeneralList = [
-  "Audiovisual",
-  "Collection",
-  "DataPaper",
-  "Dataset",
-  "Event",
-  "Image",
-  "InteractiveResource",
-  "Model",
-  "PhysicalObject",
-  "Service",
-  "Software",
-  "Sound",
-  "Text",
-  "Workflow",
-  "Other",
+  'Audiovisual',
+  'Collection',
+  'DataPaper',
+  'Dataset',
+  'Event',
+  'Image',
+  'InteractiveResource',
+  'Model',
+  'PhysicalObject',
+  'Service',
+  'Software',
+  'Sound',
+  'Text',
+  'Workflow',
+  'Other',
 ];
 
 export default Component.extend({
@@ -89,7 +89,7 @@ export default Component.extend({
   relatedIdentifierTypes: relatedIdentifierTypeList,
   controlledIdentifierType: false,
   isMetadataRelationType: false,
-  isMetadataRelationTypes: ["HasMetadata", "IsMetadataFor"],
+  isMetadataRelationTypes: [ 'HasMetadata', 'IsMetadataFor' ],
   resourceTypeGeneralList,
   resourceTypesGeneral: resourceTypeGeneralList,
 
@@ -98,19 +98,19 @@ export default Component.extend({
 
     if (
       relatedIdentifierTypeList.includes(
-        this.fragment.get("relatedIdentifierType")
+        this.fragment.get('relatedIdentifierType'),
       )
     ) {
-      this.set("controlledIdentifierType", true);
+      this.set('controlledIdentifierType', true);
     } else {
-      this.set("controlledIdentifierType", false);
+      this.set('controlledIdentifierType', false);
     }
     if (
-      this.isMetadataRelationTypes.includes(this.fragment.get("relationType"))
+      this.isMetadataRelationTypes.includes(this.fragment.get('relationType'))
     ) {
-      this.set("isMetadataRelationType", true);
+      this.set('isMetadataRelationType', true);
     } else {
-      this.set("isMetadataRelationType", false);
+      this.set('isMetadataRelationType', false);
     }
   },
   updateRelatedIdentifier(value) {
@@ -118,7 +118,7 @@ export default Component.extend({
     const lsid = /^[uU][rR][nN]:[lL][sS][iI][dD]:(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%]):(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])[:]?(A-Za-z0-9][A-Za-z0-9()+,-.=@;$_!*'"%])?$/;
     const purl = {
       require_host: true,
-      host_whitelist: ["purl.org", "oclc.org"],
+      host_whitelist: [ 'purl.org', 'oclc.org' ],
     };
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
@@ -127,53 +127,53 @@ export default Component.extend({
 
     switch (true) {
       case isBlank(value):
-        this.fragment.set("relatedIdentifier", null);
-        this.fragment.set("relatedIdentifierType", null);
-        this.set("controlledIdentifierType", false);
+        this.fragment.set('relatedIdentifier', null);
+        this.fragment.set('relatedIdentifierType', null);
+        this.set('controlledIdentifierType', false);
         this.selectResourceTypeGeneral(null);
-        this.fragment.set("schemeType", null);
-        this.fragment.set("relatedMetadataScheme", null);
-        this.fragment.set("relationType", null);
+        this.fragment.set('schemeType', null);
+        this.fragment.set('relatedMetadataScheme', null);
+        this.fragment.set('relationType', null);
         break;
       case ark.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "ARK");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'ARK');
+        this.set('controlledIdentifierType', true);
         break;
       case arxiv.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "arXiv");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'arXiv');
+        this.set('controlledIdentifierType', true);
         break;
       case doi.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "DOI");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'DOI');
+        this.set('controlledIdentifierType', true);
         break;
       case bibcode.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "bibcode");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'bibcode');
+        this.set('controlledIdentifierType', true);
         break;
       case lsid.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "LSID");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'LSID');
+        this.set('controlledIdentifierType', true);
         break;
       case isURL(value, purl):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "PURL");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'PURL');
+        this.set('controlledIdentifierType', true);
         break;
       case urn.test(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "URN");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'URN');
+        this.set('controlledIdentifierType', true);
         break;
       case isISBN(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "ISBN");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'ISBN');
+        this.set('controlledIdentifierType', true);
         break;
       // // EAN currently not supported https://github.com/validatorjs/validator.js/issues/797
       // case isEAN(value):
@@ -182,52 +182,52 @@ export default Component.extend({
       //   this.set('controlledIdentifierType', true);
       //   break;
       case isURL(value):
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", "URL");
-        this.set("controlledIdentifierType", true);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'URL');
+        this.set('controlledIdentifierType', true);
         break;
       default:
         // // Clears the relatedIdentifierType in case the user changes the relatedIdentifier after selecting it once before.
-        this.fragment.set("relatedIdentifier", value);
-        this.fragment.set("relatedIdentifierType", null);
-        this.fragment.set("relationType", null);
-        this.set("controlledIdentifierType", false);
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', null);
+        this.fragment.set('relationType', null);
+        this.set('controlledIdentifierType', false);
         break;
     }
   },
   selectRelationType(relationType) {
     if (this.isMetadataRelationTypes.includes(relationType)) {
-      this.set("isMetadataRelationType", true);
+      this.set('isMetadataRelationType', true);
     } else {
-      this.set("isMetadataRelationType", false);
-      this.fragment.set("schemeType", null);
-      this.fragment.set("relatedMetadataScheme", null);
-      this.fragment.set("resourceTypeGeneral", null);
-      this.fragment.set("schemeUri", null);
+      this.set('isMetadataRelationType', false);
+      this.fragment.set('schemeType', null);
+      this.fragment.set('relatedMetadataScheme', null);
+      this.fragment.set('resourceTypeGeneral', null);
+      this.fragment.set('schemeUri', null);
     }
-    this.fragment.set("relationType", pascalCase(relationType));
-    this.set("relationTypes", relationTypeList);
+    this.fragment.set('relationType', pascalCase(relationType));
+    this.set('relationTypes', relationTypeList);
   },
   selectRelatedIdentifierType(relatedIdentifierType) {
-    this.fragment.set("relatedIdentifierType", relatedIdentifierType);
-    this.set("relatedIdentifierTypes", relatedIdentifierTypeList);
+    this.fragment.set('relatedIdentifierType', relatedIdentifierType);
+    this.set('relatedIdentifierTypes', relatedIdentifierTypeList);
   },
   selectResourceTypeGeneral(resourceTypeGeneral) {
-    this.fragment.set("resourceTypeGeneral", pascalCase(resourceTypeGeneral));
-    this.set("resourceTypesGeneral", resourceTypeGeneralList);
+    this.fragment.set('resourceTypeGeneral', pascalCase(resourceTypeGeneral));
+    this.set('resourceTypesGeneral', resourceTypeGeneralList);
   },
   actions: {
     updateRelatedIdentifier(value) {
       this.updateRelatedIdentifier(value.trim());
     },
     updateRelatedMetadataScheme(value) {
-      this.fragment.set("relatedMetadataScheme", value);
+      this.fragment.set('relatedMetadataScheme', value);
     },
     updateSchemeURI(value) {
-      this.fragment.set("schemeUri", value);
+      this.fragment.set('schemeUri', value);
     },
     updateSchemeType(value) {
-      this.fragment.set("schemeType", value);
+      this.fragment.set('schemeType', value);
     },
     selectRelationType(relationType) {
       this.selectRelationType(relationType);
@@ -239,7 +239,7 @@ export default Component.extend({
       this.selectResourceTypeGeneral(resourceTypeGeneral);
     },
     deleteRelatedIdentifier() {
-      this.model.get("relatedIdentifiers").removeObject(this.fragment);
+      this.model.get('relatedIdentifiers').removeObject(this.fragment);
     },
   },
 });

--- a/app/components/doi-types.js
+++ b/app/components/doi-types.js
@@ -1,22 +1,22 @@
-import Component from "@ember/component";
-import { pascalCase } from "pascal-case";
+import Component from '@ember/component';
+import { pascalCase } from 'pascal-case';
 
 const resourceTypeGeneralList = [
-  "Audiovisual",
-  "Collection",
-  "DataPaper",
-  "Dataset",
-  "Event",
-  "Image",
-  "InteractiveResource",
-  "Model",
-  "PhysicalObject",
-  "Service",
-  "Software",
-  "Sound",
-  "Text",
-  "Workflow",
-  "Other",
+  'Audiovisual',
+  'Collection',
+  'DataPaper',
+  'Dataset',
+  'Event',
+  'Image',
+  'InteractiveResource',
+  'Model',
+  'PhysicalObject',
+  'Service',
+  'Software',
+  'Sound',
+  'Text',
+  'Workflow',
+  'Other',
 ];
 
 export default Component.extend({
@@ -24,10 +24,10 @@ export default Component.extend({
   resourceTypesGeneral: resourceTypeGeneralList,
 
   selectResourceTypeGeneral(resourceTypeGeneral) {
-    this.model.set("types", {
+    this.model.set('types', {
       resourceTypeGeneral: pascalCase(resourceTypeGeneral),
     });
-    this.set("resourceTypesGeneral", resourceTypeGeneralList);
+    this.set('resourceTypesGeneral', resourceTypeGeneralList);
   },
 
   actions: {

--- a/app/components/doi-types.js
+++ b/app/components/doi-types.js
@@ -1,22 +1,22 @@
-import Component from '@ember/component';
-import { pascalCase } from 'pascal-case';
+import Component from "@ember/component";
+import { pascalCase } from "pascal-case";
 
 const resourceTypeGeneralList = [
-  'Audiovisual',
-  'Collection',
-  'DataPaper',
-  'Dataset',
-  'Event',
-  'Image',
-  'Interactive resource',
-  'Model',
-  'Physical object',
-  'Service',
-  'Software',
-  'Sound',
-  'Text',
-  'Workflow',
-  'Other',
+  "Audiovisual",
+  "Collection",
+  "DataPaper",
+  "Dataset",
+  "Event",
+  "Image",
+  "InteractiveResource",
+  "Model",
+  "PhysicalObject",
+  "Service",
+  "Software",
+  "Sound",
+  "Text",
+  "Workflow",
+  "Other",
 ];
 
 export default Component.extend({
@@ -24,8 +24,10 @@ export default Component.extend({
   resourceTypesGeneral: resourceTypeGeneralList,
 
   selectResourceTypeGeneral(resourceTypeGeneral) {
-    this.model.set('types', { resourceTypeGeneral: pascalCase(resourceTypeGeneral) });
-    this.set('resourceTypesGeneral', resourceTypeGeneralList);
+    this.model.set("types", {
+      resourceTypeGeneral: pascalCase(resourceTypeGeneral),
+    });
+    this.set("resourceTypesGeneral", resourceTypeGeneralList);
   },
 
   actions: {

--- a/app/validators/resource-type.js
+++ b/app/validators/resource-type.js
@@ -1,27 +1,27 @@
 /* eslint-disable no-useless-escape */
-import BaseValidator from "ember-cp-validations/validators/base";
+import BaseValidator from 'ember-cp-validations/validators/base';
 
 const ResourceType = BaseValidator.extend({
   validate(value, options) {
     const resourceTypeGeneralList = [
-      "Audiovisual",
-      "Collection",
-      "DataPaper",
-      "Dataset",
-      "Event",
-      "Image",
-      "InteractiveResource",
-      "Model",
-      "PhysicalObject",
-      "Service",
-      "Software",
-      "Sound",
-      "Text",
-      "Workflow",
-      "Other",
+      'Audiovisual',
+      'Collection',
+      'DataPaper',
+      'Dataset',
+      'Event',
+      'Image',
+      'InteractiveResource',
+      'Model',
+      'PhysicalObject',
+      'Service',
+      'Software',
+      'Sound',
+      'Text',
+      'Workflow',
+      'Other',
     ];
 
-    const message = "Resource of the Type is not valid.";
+    const message = 'Resource of the Type is not valid.';
 
     switch (true) {
       case !value && options.allowBlank:

--- a/app/validators/resource-type.js
+++ b/app/validators/resource-type.js
@@ -1,32 +1,30 @@
 /* eslint-disable no-useless-escape */
-import BaseValidator from 'ember-cp-validations/validators/base';
+import BaseValidator from "ember-cp-validations/validators/base";
 
 const ResourceType = BaseValidator.extend({
-
   validate(value, options) {
-
     const resourceTypeGeneralList = [
-      'Audiovisual',
-      'Collection',
-      'DataPaper',
-      'Dataset',
-      'Event',
-      'Image',
-      'Interactive resource',
-      'Model',
-      'Physical object',
-      'Service',
-      'Software',
-      'Sound',
-      'Text',
-      'Workflow',
-      'Other',
+      "Audiovisual",
+      "Collection",
+      "DataPaper",
+      "Dataset",
+      "Event",
+      "Image",
+      "InteractiveResource",
+      "Model",
+      "PhysicalObject",
+      "Service",
+      "Software",
+      "Sound",
+      "Text",
+      "Workflow",
+      "Other",
     ];
 
-    const message = 'Resource of the Type is not valid.';
+    const message = "Resource of the Type is not valid.";
 
     switch (true) {
-      case (!value && options.allowBlank):
+      case !value && options.allowBlank:
         return true;
       case resourceTypeGeneralList.includes(String(value)):
         return true;


### PR DESCRIPTION
This is to allow resource type of ResourceObject
e.g. its ResourceObject not Resource object, see schema

Also fixes Interactive resource too

## Purpose
Bug fix

closes: #479 

## Approach
Match schema defs

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
