### PR TITLE
adds google tag manager configuration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -86,6 +86,10 @@ module.exports = function (environment) {
     APP_NAME: pkg.name,
     JWT_BLACKLISTED: process.env.JWT_BLACKLISTED || '',
 
+    googleTagManager: {
+      appId: process.env.GOOGLE_TAG_MANAGER_ID
+    },
+    
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/ember-feature-flags": "^4.0.6",
     "acorn": "^7.1.0",
     "cldr-core": "^36.0.0",
+    "ember-cli-google-tag-manager": "^1.0.0",
     "ember-cli-version-checker": "^3.1.3",
     "ember-decorators": "^6.1.1",
     "ember-file-upload": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10044,6 +10044,13 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
+ember-cli-google-tag-manager@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-google-tag-manager/-/ember-cli-google-tag-manager-1.0.0.tgz#e417b14ad84940fe5ae8481eef1c33b8ef7e8397"
+  integrity sha512-OsItGuysRinkeEOoSnL82+bzcNYFpRLQT76IhLdN/xn6UuTb393BF6kYTS4r0fBcOoe8GoK91ow3hEtGZBimUQ==
+  dependencies:
+    ember-cli-babel "^7.7.3"
+
 ember-cli-head@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.4.1.tgz#28b7ee86439746640834b232a3b34ab1329f3cf3"


### PR DESCRIPTION
Google tag manager is needed to measure behaviour

## Purpose
Collecting behavioural data from fabrica users.

closes: https://github.com/datacite/tasks/issues/49

## Approach

Using google tag manager to avoid having to instrumentalist all the code. 

Fabrica GTM configuration is already in GTM: https://tagmanager.google.com/#/container/accounts/6002015721/containers/40997071/workspaces/1
One just needs to copy the GTM Code. This configuration already filters analytics when the consent is rejected.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning

- GoogleTagManager (GTM) handles Consent cookie with a cookie trigger, so basically there is no need of code changes for GTM (besides the config), provided that we configure our GTM with that Trigger (already tested that as well) the consent cookie will work.

![image](https://user-images.githubusercontent.com/1092861/109331886-b215d900-785d-11eb-9ea8-c21f5f5d6788.png)


<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
