### PR TITLE
Issue #525 - The DOIs tab is not rendering correctly for inist.cea

### DIFF
--- a/app/components/creator-show.js
+++ b/app/components/creator-show.js
@@ -4,9 +4,12 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    if (this.creators.length > 50) {
-      let creators = this.creators.slice(0, 49);
-      this.set('creators', creators);
+    let limit = 50;
+    let n = this.creators.length;
+    if (n > limit) {
+      for ( var i = (n-1); i >= limit; i--) {
+        this.creators.pop;
+      }
     }
   }
 });

--- a/app/components/creator-show.js
+++ b/app/components/creator-show.js
@@ -8,7 +8,7 @@ export default Component.extend({
     let n = this.creators.length;
     if (n > limit) {
       for ( var i = (n-1); i >= limit; i--) {
-        this.creators.pop;
+        this.creators.popObject;
       }
     }
   }

--- a/app/components/creator-show.js
+++ b/app/components/creator-show.js
@@ -3,13 +3,5 @@ import Component from '@ember/component';
 export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
-
-    let limit = 50;
-    let n = this.creators.length;
-    if (n > limit) {
-      for ( var i = (n-1); i >= limit; i--) {
-        this.creators.popObject;
-      }
-    }
   }
 });

--- a/app/templates/components/creator-show.hbs
+++ b/app/templates/components/creator-show.hbs
@@ -1,9 +1,11 @@
 {{#if creators}}
   {{#each creators as |creator index|}}
-    {{#if (and creator.orcid (feature-flag 'showResearchers'))}}
-      <LinkTo @route="users.show" @model={{creator.orcid}}>{{creator.displayName~}}</LinkTo>{{format-creator creators index=index}}
-    {{else}}
-      {{creator.displayName~}}{{format-creator creators index=index}}
+    {{#if (lt index (or showOnly creators.length))}}
+      {{#if (and creator.orcid (feature-flag 'showResearchers'))}}
+        <LinkTo @route="users.show" @model={{creator.orcid}}>{{creator.displayName~}}</LinkTo>{{format-creator creators index=index}}
+      {{else}}
+        {{creator.displayName~}}{{format-creator creators index=index}}
+      {{/if}}
     {{/if}}
   {{/each}}
 {{/if}}

--- a/app/templates/components/doi-summary.hbs
+++ b/app/templates/components/doi-summary.hbs
@@ -13,7 +13,8 @@
   {{/if}}
 </h3>
 {{#if model.creators}}
-  <CreatorShow @creators={{model.creators}} />
+
+  <CreatorShow @creators={{model.creators}}  @showOnly=50 />
 {{/if}}
 <div class="metadata" data-test-metadata>
   {{format-metadata model.publicationYear resourceTypeGeneral=model.types.resourceTypeGeneral resourceType=model.types.resourceType container=model.bcontainer publisher=model.publisher version=model.version}}


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: Issue #525

## Approach
<!--- _How does this change address the problem?_ -->

The user data looks fine. This is a problem in the  Fabrica rendering code.

The sample  DOI data in the issue has more than 50 creators.   DOIs with less than 50 creators display fine.  It looks like Fabrica was trying to limit the number of creators in the display to 50.  Once the number of creators is greater than 50, the error, below, shows up in the browser console, and the page display is cut short. In this case only 3 out of 10 DOIs are displayed.

In the code, this.creators.slice makes a ’shallow copy’ of the array.  Because of this, on line 9 we are overwriting one part of the array with another part of itself.  That is being recognized as an error, and so stops display of dois on the page.

![image](https://user-images.githubusercontent.com/4681304/112991369-09e18180-9135-11eb-9da9-8cddfdcac752.png)

From the console:

![image](https://user-images.githubusercontent.com/4681304/112991398-11088f80-9135-11eb-92ea-355f2dc8175a.png)

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

I need someone to look at creater-show.js and verify that I am interpreting the code correctly.  It looks like anything over 50 creators is being removed from the render array in the original code.  The only reason it had to be changed was because it had unintended side effects.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
