### PR TITLE
Update ember build command to use production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "./node_modules/.bin/ember build",
+    "build": "./node_modules/.bin/ember build --environment=production",
     "lint": "./node_modules/.bin/eslint . --ext .js",
     "lint:hbs": "./node_modules/.bin/ember-template-lint .",
     "format:hbs": "prettier --config .prettierrc.json **/*.hbs --write",


### PR DESCRIPTION
## Purpose
Deployments of Bracco are not being built with production mode


## Approach
Updates `package.json` to add the `--environment=production` flag to the build command, because that is what Vercel uses ([Docs](https://vercel.com/docs/concepts/deployments/build-step#build-command)) 

Vercel deploy log:
![bracco-deploy](https://user-images.githubusercontent.com/93522067/143582285-bcd85bd4-eb20-410c-ba68-4b3e47984bb2.png)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
