### PR TITLE
Issue #562 - Fabrica paging for contacts list is not working correctly.

### DIFF
--- a/app/templates/providers/show/contacts/index.hbs
+++ b/app/templates/providers/show/contacts/index.hbs
@@ -139,7 +139,7 @@
         {{/each}}
         <div class="text-center">
           {{#if (gt model.contacts.meta.totalPages 1)}}
-            <PageNumbers @model={{model.contacts}} @link="contacts" />
+            <PageNumbers @model={{model.contacts}} @link="providers.show.contacts" />
           {{/if}}
         </div>
       {{else}}


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: issue #562 

## Approach
<!--- _How does this change address the problem?_ -->

Fix minor problem with link parameter for pagination template in contacts tab.

A good test page is the [DataCite Consortium contacts tab](https://doi.stage.datacite.org/providers/dc/contacts) in staging.  Log in, scroll down to the bottom of that page, the paging link '2', for example, would send the user to https://doi.stage.datacite.org/contacts?page=2 instead of http://doi.stage.datacite.org/providers/dc/contacts?page=2.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
