### PR TITLE
Issue-1454 - password visible in new password form.

### DIFF
--- a/app/templates/password.hbs
+++ b/app/templates/password.hbs
@@ -43,14 +43,14 @@
                 @required={{false}}
               />
               <form.element
-                @controlType="text"
+                @controlType="password"
                 @property="passwordInput"
                 @label="New Password"
                 @placeholder="Password"
                 @required={{false}}
               />
               <form.element
-                @controlType="text"
+                @controlType="password"
                 @property="confirmPasswordInput"
                 @label="Confirm Password"
                 @placeholder="Confirm Password"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: issue datacite/datacite#1454

## Approach

The password input fields in that form needed to be set to controlType="password".

<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
