### PR TITLE
Add 'Assign Prefix' button back to provider prefix list tab

### DIFF
--- a/app/controllers/providers/show/prefixes/index.js
+++ b/app/controllers/providers/show/prefixes/index.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
   queryParams: [ 'query', 'client-id', 'consortium-organization-id', 'year', 'state', 'sort', 'page', 'size' ],

--- a/app/controllers/providers/show/prefixes/new.js
+++ b/app/controllers/providers/show/prefixes/new.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default Controller.extend({
   store: service(),
   disabled: true,
+  prefixes_service: service('prefixes'),
 
   init(...args) {
     this._super(...args);
@@ -13,17 +14,24 @@ export default Controller.extend({
 
   searchPrefix(query) {
     let self = this;
-    this.store
-      .query('prefix', {
-        query,
-        state: 'unassigned',
-        sort: 'name',
-        'page[size]': 10
-      })
-      .then(function (prefixes) {
+    let prefixes = [];
+
+    this.prefixes_service.get_prefixes(50)
+      .then((values) => {
+        values.forEach(
+          function(value) {
+            if (value.constructor.modelName == 'prefix') {
+              let prefix = value;
+              prefixes.push(prefix);
+            } else {
+              throw new Error("Expecting a prefix object. Got something else.");
+            }
+          }
+        );
+
         self.set('prefixes', prefixes);
-      })
-      .catch(function (reason) {
+
+      }).catch(function (reason) {
         console.debug(reason);
         self.set('prefixes', []);
       });

--- a/app/templates/providers/show/prefixes/index.hbs
+++ b/app/templates/providers/show/prefixes/index.hbs
@@ -1,5 +1,51 @@
 <div class="row">
   <div class="col-md-3">
+    {{#if
+      (and
+        (can 'write index' model)
+        (not-eq model.provider.memberType 'consortium')
+        (or (eq model.currentUser.role_id 'staff_admin') model.provider.hasRequiredContacts)
+      )
+    }}
+      <div class="panel facets">
+        <div class="panel-body">
+          <div class="btn-toolbar">
+            <div class="btn-group btn-group-sm">
+              <LinkTo
+                @route="providers.show.prefixes.new"
+                @model={{model.provider.id}}
+                class="btn btn-warning"
+                id="assign-prefix"
+                @disabled={{if (eq (await (prefixes-available)) 0) "true" ""}}
+              >
+                <i class="fas fa-link"></i>
+                Assign Prefix
+              </LinkTo>
+            </div>
+          </div>
+        </div>
+      </div>
+    {{else}}
+      <div class="panel panel-transparent">
+        <div class="panel-body">
+          {{link}}
+          {{#if (eq model.provider.memberType 'consortium')}}
+            <BsAlert @dismissible={{false}} @type="warning">
+              New prefixes can't be assigned from this page.
+            </BsAlert>
+          {{else if (cannot 'create prefix' model)}}
+            <BsAlert @dismissible={{false}} @type="warning">
+              Please ask DataCite Staff if you want to add a prefix.
+            </BsAlert>
+          {{else if (not model.provider.hasRequiredContacts)}}
+            <BsAlert @dismissible={{false}} @type="warning">
+              New prefixes can't be assigned unless all required contacts are assigned.
+            </BsAlert>
+          {{/if}}
+        </div>
+      </div>
+    {{/if}}
+
     {{#if model.prefixes.meta.states}}
       <div class="panel facets add">
         <div class="panel-body">


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: issue #634 

## Approach
<!--- _How does this change address the problem?_ -->

Adds back the button that was inadvertently taken out for the prefix workflow project.  Does appropriate testing to enable/disable the button given whether there are prefixes available to assign. 

Restores the ability of staff_admin to assign prefixes to providers.

**Has been deployed to Vercel for testing at: https://bracco-eo3x454sk-datacite.vercel.app/

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
