### PR TITLE
Updated password input type from text to password

### DIFF
--- a/app/templates/change.hbs
+++ b/app/templates/change.hbs
@@ -12,8 +12,8 @@
           <div class="col-md-9 col-md-offset-3"><span class="help-block">Click <a class="action-link" {{action "generate"}} data-test-password-suggestion>here</a> for a password suggestion.</span></div>
 
           <BsForm @formLayout="horizontal" @horizontalLabelGridClass="col-md-3" @model={{model}} @onSubmit={{action "submit" model}} @submitOnEnter={{true}} as |form|>
-            <form.element @controlType="text" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
-            <form.element @controlType="text" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
+            <form.element @controlType="password" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
+            <form.element @controlType="password" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
 
             <div class="col-md-9 col-md-offset-3">
               <div class="btn-toolbar">

--- a/app/templates/providers/show/change.hbs
+++ b/app/templates/providers/show/change.hbs
@@ -5,8 +5,8 @@
     <div class="col-md-9 col-md-offset-3"><span class="help-block">Click <a class="action-link" {{action "generate"}} data-test-password-suggestion>here</a> for a password suggestion.</span></div>
 
     <BsForm @formLayout="horizontal" @horizontalLabelGridClass="col-md-3" @model={{model}} @onSubmit={{action "submit"}} @submitOnEnter={{true}} as |form|>
-      <form.element @controlType="text" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
-      <form.element @controlType="text" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
+      <form.element @controlType="password" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
+      <form.element @controlType="password" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
 
       <div class="col-md-9 col-md-offset-3">
         <div class="btn-toolbar">

--- a/app/templates/repositories/show/change.hbs
+++ b/app/templates/repositories/show/change.hbs
@@ -7,8 +7,8 @@
       </div>
 
       <BsForm @formLayout="horizontal" @horizontalLabelGridClass="col-md-3" @model={{model}} @onSubmit={{action "submit"}} @submitOnEnter={{true}} as |form|>
-        <form.element @controlType="text" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
-        <form.element @controlType="text" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
+        <form.element @controlType="password" @id="password-input" @property="passwordInput" @label="New Password" @required={{false}} />
+        <form.element @controlType="password" @id="confirm-password-input" @property="confirmPasswordInput" @label="Confirm Password" @required={{false}} />
 
         <div class="col-md-9 col-md-offset-3">
           <button type="submit" class="btn btn-sm btn-fill">Set Password</button>


### PR DESCRIPTION
## Purpose
Some of the password input fields were text inputs. This is a security risk as browsers will store previous passwords.

Closes issue #561 

## Approach
I updated them to be password input types

#### Open Questions and Pre-Merge TODOs


## Learning





## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
