### PR TITLE
Updated bar charts to always reflect current year

### DIFF
--- a/app/components/bar-chart.js
+++ b/app/components/bar-chart.js
@@ -14,7 +14,7 @@ export default Component.extend({
   tagName: 'div',
   classNames: ['col-lg-3', 'col-md-4'],
   data: null,
-  count: computed('data', 'summarize', function () {
+  count: computed('data', 'summarize', 'currentYear', function () {
     if (this.data) {
       if (this.summarize) {
         return A(this.data).reduce(function (a, b) {
@@ -23,7 +23,7 @@ export default Component.extend({
       } else {
         let currentYear = A(this.data).findBy(
           'id',
-          new Date().getFullYear().toString()
+          this.currentYear.toString()
         );
         if (currentYear) {
           return currentYear.count;
@@ -39,6 +39,7 @@ export default Component.extend({
   chartId: computed('label', function () {
     return 'chart-' + this.label.toLowerCase();
   }),
+  currentYear: new Date().getFullYear(),
   cumulative: true,
   summarize: false,
 
@@ -66,9 +67,9 @@ export default Component.extend({
     let height = 100;
     let margin = { top: 10, right: 5, bottom: 20, left: 5 };
 
-    let currentYear = new Date().getFullYear();
-    let startDate = new Date(`${currentYear - 10}-01-01`);
-    let endDate = new Date(`${currentYear + 1}-01-01`);
+    let currentYear = this.currentYear;
+    let startDate = new Date(`${currentYear - 10}-01-01 00:00:00`);
+    let endDate = new Date(`${currentYear + 1}-01-01 00:00:00`);
     let domain = [startDate, endDate];
     let length = timeYears(startDate, endDate).length;
     let width = length * 22;

--- a/app/templates/components/bar-chart.hbs
+++ b/app/templates/components/bar-chart.hbs
@@ -12,7 +12,7 @@
       {{else}}
         <LinkTo @route={{link}}>{{format-number count}}</LinkTo>
       {{/if}}
-      {{#if (not cumulative)}}<span class="small">in 2021</span>{{/if}}
+      {{#if (not cumulative)}}<span class="small">in {{currentYear}}</span>{{/if}}
     </h2>
     <div class="graphs" id={{chartId}}></div>
   </div>

--- a/tests/integration/components/index-info-test.js
+++ b/tests/integration/components/index-info-test.js
@@ -8,11 +8,15 @@ module('Integration | Component | index-info', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(hbs`{{index-info}}`);
+    
+    let currentYear = new Date().getFullYear();
+    let startDate = (currentYear - 10).toString();
+    let endDate = currentYear.toString();
 
     assert
       .dom(this.element)
       .hasText(
-        'Members by year 0 20122022 Repositories by year 0 20122022 DOIs by year 0 in 2021 20122022'
+        `Members by year 0 ${startDate+endDate} Repositories by year 0 ${startDate+endDate} DOIs by year 0 in ${currentYear.toString()} ${startDate+endDate}`
       );
   });
 });

--- a/tests/integration/components/provider-info-test.js
+++ b/tests/integration/components/provider-info-test.js
@@ -9,10 +9,14 @@ module('Integration | Component | provider-info', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`{{provider-info}}`);
 
+    let currentYear = new Date().getFullYear();
+    let startDate = (currentYear - 10).toString();
+    let endDate = currentYear.toString();
+
     assert
       .dom(this.element)
       .hasText(
-        'Repositories by year 0 20122022 DOIs by year 0 in 2021 20122022'
+        `Repositories by year 0 20122022 DOIs by year 0 in ${currentYear} ${startDate+endDate}`
       );
   });
 });

--- a/tests/integration/components/repository-info-test.js
+++ b/tests/integration/components/repository-info-test.js
@@ -9,6 +9,10 @@ module('Integration | Component | repository-info', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`{{repository-info}}`);
 
-    assert.dom(this.element).hasText('DOIs by year 0 in 2021 20122022');
+    let currentYear = new Date().getFullYear();
+    let startDate = (currentYear - 10).toString();
+    let endDate = currentYear.toString();
+
+    assert.dom(this.element).hasText(`DOIs by year 0 in ${currentYear} ${startDate+endDate}`);
   });
 });


### PR DESCRIPTION
## Purpose
The bar charts were hard coded to display the current year, and were still showing 2021.

Closes issue #609 

## Approach
I replaced references to the hard coded year to always fetch the current year.

I also added the timestamp 00:00:00 when creating the start/end dates for the graphs, because the date was using the user's timezone and offsetting the date, resulting in the graph showing the years 2011-2021 instead of 2012-2022 in some timezones.

#### Open Questions and Pre-Merge TODOs

## Learning


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
