### PR TITLE
Fix vercel build - ember-cli-clipboard depends on this package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.13.0",
+    "@babel/helper-string-parser": "~7.18.10",
     "@cypress/browserify-preprocessor": "^3.0.1",
     "@cypress/code-coverage": "^3.8.2",
     "@ember/optional-features": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-string-parser@~7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fabrica was not building on Vercel due to missing package dependency.  Ember-cli-clipboard needed @babel/helper-string-parser.  The dependency is localized so I just added the package to devDependencies.

closes: #650 

The preview build is [here](https://vercel.com/datacite/bracco/4uEpS66SzNRHKuByXEkVQzijbTri) if you want to try it out. 

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
