### PR TITLE
Adds detection of DOI URLs to related identifier component.

### DIFF
--- a/app/components/doi-related-identifier.js
+++ b/app/components/doi-related-identifier.js
@@ -144,6 +144,7 @@ export default Component.extend({
     };
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
+    const doiUrl = /^(?:(http|https):\/\/(dx.)?(doi.org|handle.test.datacite.org)?\/)(10\.\d{4,5}\/.+)/
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
     const urn = /^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]/;
 
@@ -168,6 +169,11 @@ export default Component.extend({
         this.set('controlledIdentifierType', true);
         break;
       case doi.test(value):
+        this.fragment.set('relatedIdentifier', value);
+        this.fragment.set('relatedIdentifierType', 'DOI');
+        this.set('controlledIdentifierType', true);
+        break;
+      case doiUrl.test(value):
         this.fragment.set('relatedIdentifier', value);
         this.fragment.set('relatedIdentifierType', 'DOI');
         this.set('controlledIdentifierType', true);


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Adds regex detection for DOIs with a proxy (https://doi.org) to the related identifier component in the DOI edit form. This resolves an issue where DOIs with a proxy are assigned an un-editable "URL" relatedIdentifierType value instead of "DOI".

closes: #654 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
