### PR TITLE
Fixes issue where an empty givenName and familyName could erase name field in person base component

### DIFF
--- a/app/components/person-base-component.js
+++ b/app/components/person-base-component.js
@@ -12,8 +12,6 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    this.selectNameType(this.fragment.get('nameType'));
-
     // if no givenName and familyName, and set for nameType "Personal"
     if (this.fragment.get('name') && this.fragment.get('nameType') === 'Personal' && (!this.fragment.get('givenName') || this.fragment.get('familyName'))) {
       let familyName = this.fragment.get('name').split(',', 2)[0];
@@ -24,6 +22,8 @@ export default Component.extend({
       this.fragment.set('familyName', familyName);
     }
     this.joinNameParts({});
+
+    this.selectNameType(this.fragment.get('nameType'));
 
     if (!this.fragment.get('nameIdentifiers')) {
       this.fragment.set('nameIdentifiers', []);


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Metadata with a creator/contributor that contained only a `name` property (without `givenName` or `familyName`) would produce a blank creator/contributor component in the DOI edit form.  

closes: #653 

## Approach
<!--- _How does this change address the problem?_ -->

`selectNameType` was being called before the name normalization step starting here:

https://github.com/datacite/bracco/blob/d074a02d7ba18c21f70a6d93b03ec09b373b137e/app/components/person-base-component.js#L18

This called `joinNameParts` before the normalization step. `joinNameParts` makes the fragment's `name` attribute a blank string in the absence of `givenName` and `familyName` attributes. When only the `name`  attribute is populated in the original metadata, this produces a blank form to the user. 

This PR normalizes the fragment metadata first, populating `givenName` and `familyName` before calling `joinNameParts`. This produces a populated form. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
