### PR TITLE
Fixed missing generate new repository ID button

### DIFF
--- a/app/templates/components/doi-doi.hbs
+++ b/app/templates/components/doi-doi.hbs
@@ -20,7 +20,7 @@
         helpText="Click the circle icon for a new random suffix, or the cross icon to delete the random suffix and enter a value manually."
         required=false
       }}
-      <span class="input-group-addon refresh" title="Refresh" aria-label="Refresh" {{action 'refresh'}}><i class="fas fa-refresh"></i></span>
+      <span class="input-group-addon refresh" title="Refresh" aria-label="Refresh" {{action 'refresh'}}><i class="fas fa-sync-alt"></i></span>
       <span class="input-group-addon clear" title="Clear" aria-label="Clear" {{action 'clear'}}><i class="fas fa-times-circle"></i></span>
     </div>
   </div>

--- a/app/templates/components/repository-id.hbs
+++ b/app/templates/components/repository-id.hbs
@@ -13,7 +13,7 @@
   <div class="input-group-no-float">
     {{el.control}}
 
-    <span class="input-group-addon refresh-input" title="Refresh" aria-label="Refresh" {{action 'refresh'}}><i class="fas fa-refresh"></i></span>
+    <span class="input-group-addon refresh-input" title="Refresh" aria-label="Refresh" {{action 'refresh'}}><i class="fas fa-sync-alt"></i></span>
     <span class="input-group-addon clear-input" title="Clear" aria-label="Clear" {{action 'clear'}}><i class="fas fa-times-circle"></i></span>  
   </div>
 {{/form.element}}


### PR DESCRIPTION
## Purpose
The generate new repository ID button was missing

closes: #508 

## Approach
The previously used font awesome class no longer existed, so I updated it

#### Open Questions and Pre-Merge TODOs


## Learning



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
