### PR TITLE
Fabrica improvements 8 - Register DOIs into the Future

### DIFF
--- a/app/helpers/current-year.js
+++ b/app/helpers/current-year.js
@@ -1,0 +1,7 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function currentYear([add]) {
+  return new Date().getFullYear() + parseInt(add);
+}
+
+export default buildHelper(currentYear);

--- a/app/models/doi.js
+++ b/app/models/doi.js
@@ -91,11 +91,15 @@ const Validations = buildValidations({
     }),
     validator('date', {
       after: '999',
-      before: '2023',
+      before: computed('model.maxMintFutureOffset', function () {
+        return new Date().getFullYear() + this.model.get('maxMintFutureOffset') +1;
+      }),
       precision: 'year',
       format: 'YYYY',
       errorFormat: 'YYYY',
-      message: 'Must be a year between 1000 and 2023.',
+      message: computed('model.maxMintFutureOffset', function () {
+        return `Must be a year between 1000 and ${new Date().getFullYear() + this.model.get('maxMintFutureOffset') }.`;
+      }),
       disabled: computed('model.{mode,state}', function () {
         return (
           this.model.get('state') === 'draft' ||
@@ -227,5 +231,8 @@ export default Model.extend(Validations, {
     } else {
       return null;
     }
+  }),
+  maxMintFutureOffset: computed(function () {
+    return ENV.MAX_MINT_FUTURE_OFFSET;
   })
 });

--- a/app/templates/dois/show/edit.hbs
+++ b/app/templates/dois/show/edit.hbs
@@ -48,7 +48,7 @@
         <div class="col-md-9 input-fragment">
           <div class="label-vertical">The year when the resource was or will be made publicly available.</div>
           <form.element @id="publication-year" @controlType="text" @property="publicationYear"
-            @helpText="Must be a year between 1000 and 2022." @required={{false}} />
+            @helpText="Must be a year between 1000 and {{current-year model.maxMintFutureOffset }}." @required={{false}} />
         </div>
       </div>
 

--- a/app/templates/repositories/show/dois/new.hbs
+++ b/app/templates/repositories/show/dois/new.hbs
@@ -40,7 +40,7 @@
         <div class="col-md-9 input-fragment">
           <div class="label-vertical">The year when the resource was or will be made publicly available.</div>
           <form.element @id="publication-year" @controlType="text" @property="publicationYear" @placeholder="Publication Year"
-            @helpText="Must be a year between 1000 and 2022." @required={{false}} />
+            @helpText="Must be a year between 1000 and {{current-year model.doi.maxMintFutureOffset }}." @required={{false}} />
         </div>
       </div>
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,6 +10,7 @@ module.exports = function (environment) {
   // Bring in the environment variables.
   let minPrefixesAvailable = ((typeof process.env.MIN_PREFIXES_AVAILABLE === 'undefined') || (process.env.MIN_PREFIXES_AVAILABLE == "")) ? 50 : process.env.MIN_PREFIXES_AVAILABLE;
   let showNPrefixes = ((typeof process.env.SHOW_N_PREFIXES === 'undefined') || (process.env.SHOW_N_PREFIXES == "")) ? 10 : process.env.SHOW_N_PREFIXES;
+  let maxMintFutureOffset = parseInt(((typeof process.env.MAX_MINT_FUTURE_OFFSET === 'undefined') || (process.env.MAX_MINT_FUTURE_OFFSET == "")) ? 5 : process.env.MAX_MINT_FUTURE_OFFSET);
 
   let ENV = {
     modulePrefix: 'bracco',
@@ -107,7 +108,8 @@ module.exports = function (environment) {
     },
 
     MIN_PREFIXES_AVAILABLE:  minPrefixesAvailable,
-    SHOW_N_PREFIXES: showNPrefixes
+    SHOW_N_PREFIXES: showNPrefixes,
+    MAX_MINT_FUTURE_OFFSET:  maxMintFutureOffset
   };
 
   if (fabricaDeployTarget === 'stage') {

--- a/cypress/integration/client_admin/doi.test.ts
+++ b/cypress/integration/client_admin/doi.test.ts
@@ -10,6 +10,8 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
   const waitTime = 1000;
   const waitTime2 = 2000;
   const prefix = '10.80225';
+  const dayjs = require('dayjs')
+  const yearPlusFive = dayjs().add(5, 'year').format('YYYY');
   let suffix = '';
 
   before(function () {
@@ -76,7 +78,7 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
     });
   });
 
-  it('is creating a doi - FORM', () => {
+  it.only('is creating a doi - FORM', () => {
     cy.visit('/repositories/datacite.test/dois/new');
     cy.url().should('include', '/repositories/datacite.test/dois/new').then(() => {
 
@@ -104,8 +106,11 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
       // Set publisher.
       cy.get('#publisher-field').should('be.visible').type('DataCite', { force: true });
 
+      cy.log('Year + 5 = ' + yearPlusFive);
+
       // Set publication year.
-      cy.get('#publication-year-field').should('be.visible').type('2020', { force: true });
+      cy.get('#publication-year-help').should('be.visible').should('have.text', 'Must be a year between 1000 and ' + yearPlusFive + '.');
+      cy.get('#publication-year-field').should('be.visible').type(yearPlusFive, { force: true });
 
       // Set resource type.
       // Causes the aria dropdown to be populated and displayed so that selection can be made.

--- a/cypress/integration/client_admin/doi.test.ts
+++ b/cypress/integration/client_admin/doi.test.ts
@@ -10,8 +10,8 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
   const waitTime = 1000;
   const waitTime2 = 2000;
   const prefix = '10.80225';
-  const dayjs = require('dayjs')
-  const yearPlusFive = dayjs().add(5, 'year').format('YYYY');
+  const dayjs = require('dayjs');
+  const yearPlus = dayjs().add(Cypress.env('max_mint_future_offset'), 'year').format('YYYY'); 
   let suffix = '';
 
   before(function () {
@@ -78,7 +78,7 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
     });
   });
 
-  it('is creating a doi - FORM', () => {
+  it.only('is creating a doi - FORM', () => {
     cy.visit('/repositories/datacite.test/dois/new');
     cy.url().should('include', '/repositories/datacite.test/dois/new').then(() => {
 
@@ -106,11 +106,9 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
       // Set publisher.
       cy.get('#publisher-field').should('be.visible').type('DataCite', { force: true });
 
-      cy.log('Year + 5 = ' + yearPlusFive);
-
       // Set publication year.
-      cy.get('#publication-year-help').should('be.visible').should('have.text', 'Must be a year between 1000 and ' + yearPlusFive + '.');
-      cy.get('#publication-year-field').should('be.visible').type(yearPlusFive, { force: true });
+      cy.get('#publication-year-help').should('be.visible').should('have.text', 'Must be a year between 1000 and ' + yearPlus + '.');
+      cy.get('#publication-year-field').should('be.visible').type(yearPlus, { force: true });
 
       // Set resource type.
       // Causes the aria dropdown to be populated and displayed so that selection can be made.

--- a/cypress/integration/client_admin/doi.test.ts
+++ b/cypress/integration/client_admin/doi.test.ts
@@ -78,7 +78,7 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
     });
   });
 
-  it.only('is creating a doi - FORM', () => {
+  it('is creating a doi - FORM', () => {
     cy.visit('/repositories/datacite.test/dois/new');
     cy.url().should('include', '/repositories/datacite.test/dois/new').then(() => {
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -53,6 +53,8 @@ module.exports = (on, config) => {
 
   config.env.client_admin_password = process.env.CLIENT_ADMIN_PASSWORD
 
+  config.env.max_mint_future_offset = process.env.MAX_MINT_FUTURE_OFFSET || 5
+
   on('task', {
     // deconstruct the individual properties
     hello({ greeting, name }) {

--- a/dotenv.js
+++ b/dotenv.js
@@ -27,6 +27,7 @@ module.exports = function () {
       'CLIENT_ADMIN_USERNAME',
       'ENABLE_DOI_ESTIMATE',
       'MIN_PREFIXES_AVAILABLE',
+      'MAX_MINT_FUTURE_OFFSET',
       'SHOW_N_PREFIXES'
     ],
     fastbootAllowedKeys: [
@@ -56,6 +57,7 @@ module.exports = function () {
       'CLIENT_ADMIN_USERNAME',
       'ENABLE_DOI_ESTIMATE',
       'MIN_PREFIXES_AVAILABLE',
+      'MAX_MINT_FUTURE_OFFSET',
       'SHOW_N_PREFIXES'
     ],
     failOnMissingKey: false

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "d3-shape": "^1.3.7",
     "d3-time": "^1.1.0",
     "d3-time-format": "^2.2.3",
+    "dayjs": "^1.11.7",
     "devtron": "^1.4.0",
     "dynamic-link": "^0.2.5",
     "edtf": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9812,6 +9812,11 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
   integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fabrica improvement #8: Allow specified publication year for dois to be up to 5 years into the future.

closes: [datacite/datacite#1](https://github.com/datacite/datacite/issues/1519)

Vercel Preview: https://bracco-dc127st94-datacite.vercel.app/

## Approach
<!--- _How does this change address the problem?_ -->

Added changes already added by Kristian in PR #626.  Modified the cypress test under client_admin=>create doi to add a DOI published 5 years ahead of the current year.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
