### PR TITLE
Fabrica-improvements-11: Link user pages to Commons

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -67,11 +67,6 @@ Router.map(function () {
     this.route('new');
   });
   this.route('users', function () {
-    this.route('show', { path: '/:user_id' }, function () {
-      this.route('info');
-      this.route('settings');
-      this.route('dois');
-    });
   });
   this.route('contacts', function () {
     this.route('show', { path: '/:contact_id' }, function () {

--- a/app/templates/components/creator-show.hbs
+++ b/app/templates/components/creator-show.hbs
@@ -1,7 +1,7 @@
 {{#if creators}}
   {{#each (take (or showOnly creators.length) creators) as |creator index|}}
     {{#if (and creator.orcid (feature-flag 'showResearchers'))}}
-      <LinkTo @route="users.show" @model={{creator.orcid}}>{{creator.displayName~}}</LinkTo>{{format-creator creators index=index}}
+      <a href="https://commons.datacite.org/orcid.org/{{creator.orcid}}">{{creator.displayName~}}</a>{{format-creator creators index=index}}
     {{else}}
       {{creator.displayName~}}{{format-creator creators index=index showOnly=(or showOnly creators.length)}}
     {{/if}}

--- a/app/templates/components/user-list.hbs
+++ b/app/templates/components/user-list.hbs
@@ -15,7 +15,7 @@
       <div class="panel panel-transparent" data-test-user>
         <div class="panel-body">
           <h3 class="work">
-            <LinkTo @route="users.show" @model={{user.id}}>{{user.name}}</LinkTo>
+            <a href="https://commons.datacite.org/orcid.org/{{user.id}}">{{user.name}}</a>
           </h3>
 
           <h5>ORCID</h5>


### PR DESCRIPTION
## Purpose
Remove user profile pages from Fabrica and redirect to Commons
[Vercel Build](https://bracco-hrhdqqkxc-datacite.vercel.app/)

closes: https://github.com/datacite/datacite/issues/1522

## Approach
I removed the links to the user profile pages on Fabrica and replaced them with a redirect to the Commons user page

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
