### PR TITLE
Issue 705: Create DOI button requires user to...

### DIFF
--- a/app/components/create-doi-button.js
+++ b/app/components/create-doi-button.js
@@ -11,4 +11,10 @@ export default Component.extend({
 
     this.set('currentUser', this.currentUser);
   },
+
+  actions: {
+    createDoi() {
+      this.router.transitionTo('repositories.show.dois.new');
+    }
+  }
 });

--- a/app/styles/local.css
+++ b/app/styles/local.css
@@ -30,7 +30,7 @@
   background-color: rgb(128, 128, 128, .1);
 }
 
-.create-doi-button button a {
+.create-doi-button button {
   font-size: 16px !important;
 }
 

--- a/app/templates/components/create-doi-button.hbs
+++ b/app/templates/components/create-doi-button.hbs
@@ -1,7 +1,7 @@
 <div style="display: inline-block; width: 100%;">
 <BsDropdown as |dd|>
-  <BsButton class="btn-warning">
-    {{#link-to "repositories.show.dois.new" class='btn-warning transparent-background' title='Using DOI Form' id="omnipresent-new-doi"}}<i class="fas fa-edit"></i>Create DOI{{/link-to}}
+  <BsButton class="btn-warning" @onClick={{action "createDoi"}} id="omnipresent-new-doi" title='Create DOI Using Form'>
+    <i class="fas fa-edit"></i>Create DOI
   </BsButton>
   <dd.button class="btn-warning"><span class="caret caret-point"></span></dd.button>
   <dd.menu as |ddm|>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bracco",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "description": "Fabrica",
   "repository": {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #705

## Approach
<!--- _How does this change address the problem?_ -->

Don't use a link within a button - use `<BsButton>` and an action.  The hover styles and link would only take affect when over the link, itself.  There were some areas of the button where that wouldn't happen.

Had to move the `id="omnipresent-new-doi"` from the `<a>` tag to the `<button>` tag.  It should still be trackable.

Vercel preview: https://vercel.com/datacite/bracco/5wxaGr3ATnB7oYkh1ij5ukcELJhz

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->



## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
