### PR TITLE
Fixes errors when viewing DOIs with unexpected Creative Commons rightsURIs

### DIFF
--- a/app/components/cc-license.js
+++ b/app/components/cc-license.js
@@ -24,7 +24,7 @@ export default Component.extend({
       let uri = new URI(this.licenseURL);
       let licenseLogo = null;
       if (uri.hostname() === 'creativecommons.org') {
-        let labels = A(uri.segment(1).split('-'));
+        let labels = A(uri.segment(1)?.split('-'));
         labels.unshift('cc');
         let val = null;
 


### PR DESCRIPTION
Fixes #707

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

DOIs with unexpected Creative Commons rightsURIs can cause Fabrica to become unresponsive. 

closes: #707 

## Approach
<!--- _How does this change address the problem?_ -->

Adds optional chaining for URI segments. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] May be more advantageous in the future to include a regex check for CC licenses in an expected format. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
