### PR TITLE
Fix allowing URL-format DOIs in relatedIdentifier and relatedItemIdentifier fields in form

### DIFF
--- a/app/components/doi-related-item-identifier.js
+++ b/app/components/doi-related-item-identifier.js
@@ -60,6 +60,7 @@ export default Component.extend({
     };
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
+    const doiUrl = /^(?:(http|https):\/\/(dx.)?(doi.org|handle.test.datacite.org)?\/)(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
     const urn = /^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]/;
 
@@ -80,6 +81,11 @@ export default Component.extend({
         this.set('controlledIdentifierType', true);
         break;
       case doi.test(value):
+        this.fragment.set('relatedItemIdentifier', value);
+        this.fragment.set('relatedItemIdentifierType', 'DOI');
+        this.set('controlledIdentifierType', true);
+        break;
+      case doiUrl.test(value):
         this.fragment.set('relatedItemIdentifier', value);
         this.fragment.set('relatedItemIdentifierType', 'DOI');
         this.set('controlledIdentifierType', true);

--- a/app/validators/identifier-format.js
+++ b/app/validators/identifier-format.js
@@ -10,6 +10,7 @@ const IdentifierFormat = BaseValidator.extend({
     const purl = {require_host: true, host_whitelist: [ 'purl.org', 'oclc.org' ]};
     const arxiv = /^(arXiv:)(\d{4}.\d{4,5}|[a-z\-]+(\.[A-Z]{2})?\/\d{7})(v\d+)?/;
     const doi = /^(10\.\d{4,5}\/.+)/;
+    const doiUrl = /^(?:(http|https):\/\/(dx.)?(doi.org|handle.test.datacite.org)?\/)(10\.\d{4,5}\/.+)/;
     const bibcode = /\d{4}[A-Za-z\.\&]{5}[\w\.]{4}[ELPQ-Z\.][\d\.]{4}[A-Z]/;
     const urn = /^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]/;
     const types = [ 'EAN13', 'EISSN', 'Handle', 'IGSN', 'ISSN', 'ISTC', 'LISSN', 'LSID', 'PMID',  'UPC', 'w3id' ];
@@ -20,7 +21,7 @@ const IdentifierFormat = BaseValidator.extend({
       case model.relatedIdentifierType == 'arXiv':
         return arxiv.test(value) ? true : 'Please enter a valid arXiv.';
       case model.relatedIdentifierType == 'DOI':
-        return doi.test(value) ? true : 'Please enter a valid DOI.';
+        return doi.test(value) || doiUrl.test(value) ? true : 'Please enter a valid DOI.';
       case model.relatedIdentifierType == 'bibcode':
         return bibcode.test(value) ? true : 'Please enter a valid bibcode.';
       case model.relatedIdentifierType == 'LSID':

--- a/cypress/e2e/client_admin/doi.test.ts
+++ b/cypress/e2e/client_admin/doi.test.ts
@@ -215,23 +215,22 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
       // Set related identifier.
       cy.get('#add-related-identifier').click({ force: true }).then(($subform) => {
         cy.get('[data-test-related-identifier]').should('be.visible').type('10.0330/skv0002', { force: true }).then(() => {
-
           cy.get('[data-test-related-identifier-type] .ember-power-select-selected-item').contains('DOI');
+        });
+        cy.get('[data-test-related-identifier]').should('be.visible').type('{selectAll}https://doi.org/10.1080/00393630.2018.1504449', { force: true }).then(() => {
+          cy.get('[data-test-related-identifier-type] .ember-power-select-selected-item').contains('DOI');
+        });
+        // Causes the aria dropdown to be populated and displayed so that selection can be made.
+        cy.get('[data-test-related-relation-type] div[role="button"]').click({ force: true }).then(() => {
+          // Makes the selection from the dropdown. (Type it.)
+          cy.get('input.ember-power-select-search-input').type('References{enter}', { force: true }).then(() => {
 
-          // Causes the aria dropdown to be populated and displayed so that selection can be made.
-          cy.get('[data-test-related-relation-type] div[role="button"]').click({ force: true }).then(() => {
-            // Makes the selection from the dropdown. (Type it.)
-            cy.get('input.ember-power-select-search-input').type('References{enter}', { force: true }).then(() => {
-
-              // Causes the aria dropdown to be populated and displayed so that selection can be made.
-              cy.get('[data-test-related-resource-type] div[role="button"]').click({ force: true }).then(() => {
-                // Makes the selection from the dropdown. (Type or click on it.  Since choices change as you type, that is the better method.)
-                cy.get('input.ember-power-select-search-input').first().type('Text{enter}', { force: true }).then(() => {
-
-                  cy.get('#toggle-related-identifiers').should('be.visible').click({ force: true }).then(($toggle) => {
-                    cy.get('#toggle-related-identifiers').contains('Show 1 related identifier');
-                  });
-
+            // Causes the aria dropdown to be populated and displayed so that selection can be made.
+            cy.get('[data-test-related-resource-type] div[role="button"]').click({ force: true }).then(() => {
+              // Makes the selection from the dropdown. (Type or click on it.  Since choices change as you type, that is the better method.)
+              cy.get('input.ember-power-select-search-input').first().type('Text{enter}', { force: true }).then(() => {
+                cy.get('#toggle-related-identifiers').should('be.visible').click({ force: true }).then(($toggle) => {
+                  cy.get('#toggle-related-identifiers').contains('Show 1 related identifier');
                 });
               });
             });
@@ -278,7 +277,10 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
           // Check that the type is set
           cy.get('[data-test-related-item-identifier-type]').contains('DOI')
         })
-
+        cy.get('[data-test-related-item-identifier]').should('be.visible').type('{selectAll}https://doi.org/10.1080/00393630.2018.1504449').then(() => {
+          // Check that the type is set
+          cy.get('[data-test-related-item-identifier-type]').contains('DOI')
+        })
         // Check the toggle
         cy.get('#toggle-related-items').should('be.visible').click({ force: true }).then(($toggle) => {
           cy.get('#toggle-related-items').contains('Show 1 related item');


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Corrects behavior where URL-format DOIs would not validate correctly in the form for relatedIdentifiers. Adds auto-detection of URL-format DOIs to relatedItemIdentifier field. 

closes: #709 

## Approach
<!--- _How does this change address the problem?_ -->

URL-format DOI regex is added to the validator for relatedIdentifier and to the identifier auto-detection for relatedItemIdentifier. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
