### PR TITLE
Get scheme URI for subject SchemeURI field

### DIFF
--- a/app/models/subject.js
+++ b/app/models/subject.js
@@ -20,7 +20,7 @@ export default Fragment.extend(Validations, {
   valueUri: attr('string', { defaultValue: "" }),
   classificationCode: attr('string', { defaultValue: null }),
 
-  subjectSchemeUri: computed('valueUri', function () {
-    return this.valueUri || '';
+  subjectSchemeUri: computed('schemeUri', function () {
+    return this.schemeUri || '';
   })
 });


### PR DESCRIPTION
This changes from getting valueURI to schemeURI.

## Purpose

To avoid the confusion when looking at data that has a valueURI and then opens the form, see related issue for further notes.
Without getting into redesigning this area, a simple change is to just get the schemeURI as this is less confusing.

closes: datacite/datacite#1287

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
