### PR TITLE
"Add another affiliation" appears when editing a DOI in form if creator doesn't already have affiliations

### DIFF
--- a/app/templates/components/doi-creator.hbs
+++ b/app/templates/components/doi-creator.hbs
@@ -76,10 +76,10 @@
       Affiliation names and identifiers are provided by the Research Organization Registry (ROR).
     </div>
   {{/if}}
+{{/if}}
 
-  {{#if (lte fragment.affiliation.length 2)}}
-    <BsButton @class="btn-sm add-affiliation" @outline={{true}} @onClick={{action "addAffiliation"}}><i class="fas fa-plus-circle"></i> Add another affiliation</BsButton>
-  {{/if}}
+{{#if (lte fragment.affiliation.length 2)}}
+  <BsButton @class="btn-sm add-affiliation" @outline={{true}} @onClick={{action "addAffiliation"}}><i class="fas fa-plus-circle"></i> Add another affiliation</BsButton>
 {{/if}}
 
 <hr />

--- a/cypress/e2e/client_admin/doi.test.ts
+++ b/cypress/e2e/client_admin/doi.test.ts
@@ -13,7 +13,8 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
   const dayjs = require('dayjs');
   const yearInRange = dayjs().add(Cypress.env('max_mint_future_offset'), 'year').format('YYYY');
   const yearOutOfRange = String(Number(yearInRange) + 1);
-  let suffix = '';
+
+  const creator = 'Miller, Elizabeth';
 
   before(function () {
     cy.login(Cypress.env('client_admin_username'), Cypress.env('client_admin_password'));
@@ -93,7 +94,7 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
 
       // Set creator.
       cy.get('.help-block.name-identifier-field').should('be.visible').should('have.text','Use name identifier expressed as URL. Uniquely identifies an individual or legal entity, according to various schemas, e.g. ORCID, ROR or ISNI. The Given Name, Family Name, and Name will automatically be filled out for ORCID and ROR identifiers.')
-      cy.get('input[data-test-name]').should('be.visible').type('Miller, Elizabeth', { force: true });
+      cy.get('input[data-test-name]').should('be.visible').type(creator, { force: true });
       cy.get('#toggle-creators').should('be.visible').click({ force: true }).then(($toggle) => {
         cy.get('#toggle-creators').contains('Show 1 creator');
       });
@@ -297,6 +298,11 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
 
     }).then(() => {
 
+      // Get the suffix for later tests
+      cy.get("#suffix-field").invoke('val').then( (value) => {
+        Cypress.env('suffix', value)
+      });
+
       ////////// DONE FILLING IN FORM.  PRESS THE CREATE BUTTON.
 
       cy.get('button#doi-create').should('be.visible').click();
@@ -304,6 +310,19 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
       cy.location('pathname').should('contain', '/dois/' + prefix)
     });
   });
+
+  it('is editing a doi - FORM', () => {
+    cy.visit('/dois/' + encodeURIComponent(prefix + '/' + Cypress.env('suffix')) + '/edit');
+    cy.url().should('include', '/dois/' + encodeURIComponent(prefix + '/' + Cypress.env('suffix')) + '/edit').then(() => {
+
+      cy.wait(waitTime);
+      // Get entered creator.
+      cy.get('input[data-test-name]').should('be.visible').should('have.value', creator)
+      cy.get('.add-name-identifier').should('be.visible')
+      cy.get('.add-affiliation').should('be.visible')
+
+    })
+  })
 
   it('is creating a doi - FILE UPLOAD', () => {
     cy.visit('/repositories/datacite.test/dois/upload');


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Bug fix to include "Add another affiliation" button when editing a DOI in the form if a creator doesn't already have affiliations. 

closes: #739

## Approach
<!--- _How does this change address the problem?_ -->

Modifies a bug in the `doi-creator` template and adds a test called `is editing a doi - FORM` for the DOI `edit` route to improve e2e testing for the form. The new test can be expanded in the future to better test the continuity of data between the form and the DOI `edit` route. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
