### PR TITLE
Remove contacts created during Cypress tests at end of tests

### DIFF
--- a/cypress/e2e/consortium_admin/contact.test.ts
+++ b/cypress/e2e/consortium_admin/contact.test.ts
@@ -18,13 +18,11 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
   const min = 500000;
   const max = 999999;
   const consortium_id = Cypress.env('consortium_admin_username').toLowerCase()
+  const test_contact_family_name_prefix = "ABCD"
 
   before(function () {
     cy.login(Cypress.env('consortium_admin_username'), Cypress.env('consortium_admin_password'));
     cy.setCookie('_consent', 'true');
-    cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(consortium_id, Cypress.env('api_url'), cookie.value)
-    })
   })
 
   beforeEach(() => {
@@ -34,7 +32,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
 
   after(() => {
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(consortium_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(consortium_id, test_contact_family_name_prefix, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -62,7 +60,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     // Create a contact to be searched for.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = [];
@@ -89,7 +87,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     // Create a contact to be searched for.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -138,7 +136,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
   it('create a contact', () => {
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
     cy.visit('/providers/' + consortium_id + '/contacts/new');
@@ -182,7 +180,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     // Create a contact to be visited.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -209,7 +207,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     // Create a contact to be updated.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -244,7 +242,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     // Create a contact to be deleted.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];

--- a/cypress/e2e/consortium_admin/contact.test.ts
+++ b/cypress/e2e/consortium_admin/contact.test.ts
@@ -23,7 +23,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     cy.login(Cypress.env('consortium_admin_username'), Cypress.env('consortium_admin_password'));
     cy.setCookie('_consent', 'true');
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderContacts(consortium_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(consortium_id, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -31,6 +31,12 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     Cypress.Cookies.preserveOnce('_fabrica', '_jwt', '_consent');
     cy.wait(waitTime2);
   });
+
+  after(() => {
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderTestContacts(consortium_id, Cypress.env('api_url'), cookie.value)
+    })
+  })
 
   it('visiting contacts for member', () => {
     cy.visit('/providers/' + consortium_id + '/contacts');

--- a/cypress/e2e/consortium_admin/contact.test.ts
+++ b/cypress/e2e/consortium_admin/contact.test.ts
@@ -15,12 +15,16 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
   const waitTime2 = 2000;
   const waitTime3 = 3000;
   const waitTime4 = 4000;
-  const min = 5000;
-  const max = 9999;
+  const min = 500000;
+  const max = 999999;
+  const consortium_id = Cypress.env('consortium_admin_username').toLowerCase()
 
   before(function () {
     cy.login(Cypress.env('consortium_admin_username'), Cypress.env('consortium_admin_password'));
     cy.setCookie('_consent', 'true');
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderContacts(consortium_id, Cypress.env('api_url'), cookie.value)
+    })
   })
 
   beforeEach(() => {
@@ -29,8 +33,8 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
   });
 
   it('visiting contacts for member', () => {
-    cy.visit('/providers/dc/contacts');
-    cy.url().should('include', '/providers/dc/contacts')
+    cy.visit('/providers/' + consortium_id + '/contacts');
+    cy.url().should('include', '/providers/' + consortium_id + '/contacts')
     cy.wait(waitTime);
 
     // Has Fabrica logo and correct navbar color
@@ -55,16 +59,15 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'dc';
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, consortium_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
-        cy.visit('/providers/dc/contacts');
-        cy.url().should('include', '/providers/dc/contacts')
+        cy.visit('/providers/' + consortium_id + '/contacts');
+        cy.url().should('include', '/providers/' + consortium_id + '/contacts')
         cy.wait(waitTime)
 
         cy.get('input[name="query"]')
@@ -83,16 +86,15 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'dc';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, consortium_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
-        cy.visit('/providers/dc/contacts');
-        cy.url().should('include', '/providers/dc/contacts')
+        cy.visit('/providers/' + consortium_id + '/contacts');
+        cy.url().should('include', '/providers/' + consortium_id + '/contacts')
         cy.wait(waitTime)
 
         cy.get('a#role-name-service')
@@ -133,8 +135,8 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
-    cy.visit('/providers/dc/contacts/new');
-    cy.url().should('include', '/providers/dc/contacts/new').then(() => {
+    cy.visit('/providers/' + consortium_id + '/contacts/new');
+    cy.url().should('include', '/providers/' + consortium_id + '/contacts/new').then(() => {
       cy.wait(waitTime);
 
       cy.get('h3.edit').contains('Add Contact');
@@ -158,7 +160,7 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
       cy.get('button#add-contact').should('be.visible').click({force: true}).then(() => {
         cy.wait(waitTime);
         cy.location().should((loc) => {
-          //expect(loc.pathname).to.contain('/providers/dc');
+          //expect(loc.pathname).to.contain('/providers/' + consortium_id);
           expect(loc.pathname).to.contain('/contacts/');
         });
       });
@@ -177,12 +179,11 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'dc';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, consortium_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id);
@@ -205,12 +206,11 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'dc';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, consortium_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id + '/edit');
@@ -241,12 +241,11 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'dc';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, consortium_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id + '/delete');

--- a/cypress/e2e/organization_admin/contact.test.ts
+++ b/cypress/e2e/organization_admin/contact.test.ts
@@ -18,13 +18,11 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
   const min = 500000;
   const max = 999999;
   const provider_id = Cypress.env('organization_admin_username').toLowerCase()
+  const test_contact_family_name_prefix = "ABCD"
 
   before(function () {
     cy.login(Cypress.env('organization_admin_username'), Cypress.env('organization_admin_password'));
     cy.setCookie('_consent', 'true');
-    cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
-    })
   })
 
   beforeEach(() => {
@@ -34,7 +32,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
 
   after(() => {
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(provider_id, test_contact_family_name_prefix, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -63,7 +61,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     // Create a contact to be searched for.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = [];
@@ -92,7 +90,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     // Create a contact for filters.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -141,7 +139,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
   it('create a contact', () => {
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
     cy.visit('/providers/' + provider_id + '/contacts/new');
@@ -179,7 +177,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     // Create a contact to be visited.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -206,7 +204,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     // Create a contact to be updated.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     updated_given_name = 'Jonathan';
     updated_email = updated_given_name + '.' + family_name + '@example.org';
@@ -250,7 +248,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     // Create a contact to be deleted.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];

--- a/cypress/e2e/organization_admin/contact.test.ts
+++ b/cypress/e2e/organization_admin/contact.test.ts
@@ -23,7 +23,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     cy.login(Cypress.env('organization_admin_username'), Cypress.env('organization_admin_password'));
     cy.setCookie('_consent', 'true');
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderContacts(provider_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -31,6 +31,12 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     Cypress.Cookies.preserveOnce('_fabrica', '_jwt', '_consent');
     cy.wait(waitTime2);
   });
+
+  after(() => {
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
+    })
+  })
 
   it('visiting contacts for member', () => {
     cy.visit('/providers/' + provider_id + '/contacts');

--- a/cypress/e2e/organization_admin/contact.test.ts
+++ b/cypress/e2e/organization_admin/contact.test.ts
@@ -15,12 +15,16 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
   const waitTime2 = 2000;
   const waitTime3 = 3000;
   const waitTime4 = 4000;
-  const min = 5000;
-  const max = 9999;
+  const min = 500000;
+  const max = 999999;
+  const provider_id = Cypress.env('organization_admin_username').toLowerCase()
 
   before(function () {
     cy.login(Cypress.env('organization_admin_username'), Cypress.env('organization_admin_password'));
     cy.setCookie('_consent', 'true');
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderContacts(provider_id, Cypress.env('api_url'), cookie.value)
+    })
   })
 
   beforeEach(() => {
@@ -29,9 +33,9 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
   });
 
   it('visiting contacts for member', () => {
-    cy.visit('/providers/datacite/contacts');
+    cy.visit('/providers/' + provider_id + '/contacts');
     cy.location().should((loc) => {
-      expect(loc.pathname).to.eq('/providers/datacite/contacts');
+      expect(loc.pathname).to.eq('/providers/' + provider_id + '/contacts');
     });
 
     // Has Fabrica logo and correct navbar color
@@ -56,16 +60,15 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
-        cy.visit('/providers/datacite/contacts');
-        cy.url().should('include', '/providers/datacite/contacts')
+        cy.visit('/providers/' + provider_id + '/contacts');
+        cy.url().should('include', '/providers/' + provider_id + '/contacts')
         cy.wait(waitTime)
 
         cy.get('input[name="query"]')
@@ -86,16 +89,15 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
-        cy.visit('/providers/datacite/contacts');
-        cy.url().should('include', '/providers/datacite/contacts')
+        cy.visit('/providers/' + provider_id + '/contacts');
+        cy.url().should('include', '/providers/' + provider_id + '/contacts')
         cy.wait(waitTime)
 
         cy.get('a#role-name-service')
@@ -136,8 +138,8 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
-    cy.visit('/providers/datacite/contacts/new');
-    cy.url().should('include', '/providers/datacite/contacts/new').then(() => {
+    cy.visit('/providers/' + provider_id + '/contacts/new');
+    cy.url().should('include', '/providers/' + provider_id + '/contacts/new').then(() => {
       cy.wait(waitTime);
 
       cy.get('h3.edit').contains('Add Contact');
@@ -174,12 +176,11 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id);
@@ -204,12 +205,11 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     updated_given_name = 'Jonathan';
     updated_email = updated_given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id + '/edit');
@@ -247,12 +247,11 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
 
@@ -275,7 +274,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
 
         cy.get('button#delete').contains('Delete').click({force: true});
         cy.location().should((loc) => {
-          expect(loc.pathname).to.eq('/providers/datacite/contacts');
+          expect(loc.pathname).to.eq('/providers/' + provider_id + '/contacts');
         });
       });
     });
@@ -283,9 +282,9 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
 
   // TBD - custom command for adding service contact to repository so we can test this.
   it('show member settings', () => {
-    cy.visit('/providers/datacite/settings');
+    cy.visit('/providers/' + provider_id + '/settings');
     cy.location().should((loc) => {
-      expect(loc.pathname).to.eq('/providers/datacite/settings');
+      expect(loc.pathname).to.eq('/providers/' + provider_id + '/settings');
     });
 
     cy.get('h2.work').contains('DataCite');

--- a/cypress/e2e/staff_admin/contact.test.ts
+++ b/cypress/e2e/staff_admin/contact.test.ts
@@ -26,7 +26,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     cy.login(Cypress.env('staff_admin_username'), Cypress.env('staff_admin_password'));
     cy.setCookie('_consent', 'true');
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderContacts(provider_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -34,6 +34,12 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     Cypress.Cookies.preserveOnce('_fabrica', '_jwt', '_consent');
     cy.wait(waitTime2);
   });
+
+  after(() => {
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
+    })
+  })
 
   it('search contacts', () => {
     // Create a contact to be searched for.
@@ -217,8 +223,8 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
       cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
-        cy.visit('/contacts/' + provider_id + '/edit');
-        cy.url().should('include', '/contacts/' + provider_id + '/edit')
+        cy.visit('/contacts/' + id + '/edit');
+        cy.url().should('include', '/contacts/' + id + '/edit')
         cy.wait(waitTime);
 
         cy.get('h2.work').contains(given_name + ' ' + family_name);
@@ -237,7 +243,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
           .then(() => {
             cy.wait(waitTime);
             cy.location().should((loc) => {
-              expect(loc.pathname).to.eq('/contacts/' + provider_id);
+              expect(loc.pathname).to.eq('/contacts/' + id);
             });
             cy.get('h2.work').contains(updated_given_name + ' ' + family_name);
           });
@@ -260,8 +266,8 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
 
-        cy.visit('/contacts/' + provider_id);
-        cy.url().should('include', '/contacts/' + provider_id);
+        cy.visit('/contacts/' + id);
+        cy.url().should('include', '/contacts/' + id);
         cy.wait(waitTime);
 
         cy.get('a#delete-contact').contains('Delete Contact').click();

--- a/cypress/e2e/staff_admin/contact.test.ts
+++ b/cypress/e2e/staff_admin/contact.test.ts
@@ -21,13 +21,11 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
   const min = 500000;
   const max = 999999;
   const provider_id = Cypress.env('organization_admin_username').toLowerCase()
+  const test_contact_family_name_prefix = "ABCD"
 
   before(function () {
     cy.login(Cypress.env('staff_admin_username'), Cypress.env('staff_admin_password'));
     cy.setCookie('_consent', 'true');
-    cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
-    })
   })
 
   beforeEach(() => {
@@ -37,7 +35,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
 
   after(() => {
     cy.getCookie('_jwt').then((cookie) => {
-      cy.deleteProviderTestContacts(provider_id, Cypress.env('api_url'), cookie.value)
+      cy.deleteProviderTestContacts(provider_id, test_contact_family_name_prefix, Cypress.env('api_url'), cookie.value)
     })
   })
 
@@ -45,7 +43,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     // Create a contact to be searched for.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = [];
@@ -82,7 +80,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     // Create a contact for filters.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Sack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing", "voting", "secondary_billing"];
@@ -146,7 +144,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
   it('create a contact', () => {
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
     cy.visit('/providers/' + provider_id + '/contacts/new');
@@ -184,7 +182,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     // Create a contact to be visited.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
@@ -211,7 +209,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     // Create a contact to be updated.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     updated_given_name = 'Jonathan';
     updated_email = updated_given_name + '.' + family_name + '@example.org';
@@ -255,7 +253,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     // Create a contact to be deleted.
     const rndInt = randomIntFromInterval(min, max);
     given_name = 'Jack';
-    family_name = 'Smith' + rndInt;
+    family_name = test_contact_family_name_prefix + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];

--- a/cypress/e2e/staff_admin/contact.test.ts
+++ b/cypress/e2e/staff_admin/contact.test.ts
@@ -18,12 +18,16 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
   const waitTime2 = 2000;
   const waitTime3 = 3000;
   const waitTime4 = 4000;
-  const min = 5000;
-  const max = 9999;
+  const min = 500000;
+  const max = 999999;
+  const provider_id = Cypress.env('organization_admin_username').toLowerCase()
 
   before(function () {
     cy.login(Cypress.env('staff_admin_username'), Cypress.env('staff_admin_password'));
     cy.setCookie('_consent', 'true');
+    cy.getCookie('_jwt').then((cookie) => {
+      cy.deleteProviderContacts(provider_id, Cypress.env('api_url'), cookie.value)
+    })
   })
 
   beforeEach(() => {
@@ -38,11 +42,10 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
@@ -76,11 +79,10 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     roles = ["service", "secondary_service", "technical", "secondary_technical", "billing", "voting", "secondary_billing"];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
@@ -141,8 +143,8 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
 
-    cy.visit('/providers/datacite/contacts/new');
-    cy.url().should('include', '/providers/datacite/contacts/new').then(() => {
+    cy.visit('/providers/' + provider_id + '/contacts/new');
+    cy.url().should('include', '/providers/' + provider_id + '/contacts/new').then(() => {
       cy.wait(waitTime);
 
       cy.get('h3.edit').contains('Add Contact');
@@ -179,12 +181,11 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         cy.visit('/contacts/' + id);
@@ -209,16 +210,15 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     updated_given_name = 'Jonathan';
     updated_email = updated_given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
-        cy.visit('/contacts/' + id + '/edit');
-        cy.url().should('include', '/contacts/' + id + '/edit')
+        cy.visit('/contacts/' + provider_id + '/edit');
+        cy.url().should('include', '/contacts/' + provider_id + '/edit')
         cy.wait(waitTime);
 
         cy.get('h2.work').contains(given_name + ' ' + family_name);
@@ -237,7 +237,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
           .then(() => {
             cy.wait(waitTime);
             cy.location().should((loc) => {
-              expect(loc.pathname).to.eq('/contacts/' + id);
+              expect(loc.pathname).to.eq('/contacts/' + provider_id);
             });
             cy.get('h2.work').contains(updated_given_name + ' ' + family_name);
           });
@@ -252,17 +252,16 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
     family_name = 'Smith' + rndInt;
     email = given_name + '.' + family_name + '@example.org';
     type = 'providers';
-    id = 'datacite';
     //roles = ["service", "secondary_service", "technical", "secondary_technical", "billing"];
     roles = [];
 
     cy.getCookie('_jwt').then((cookie) => {
-      cy.createContact(email, given_name, family_name, roles, type, id, Cypress.env('api_url'), cookie.value).then((id) => {
+      cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
 
-        cy.visit('/contacts/' + id);
-        cy.url().should('include', '/contacts/' + id);
+        cy.visit('/contacts/' + provider_id);
+        cy.url().should('include', '/contacts/' + provider_id);
         cy.wait(waitTime);
 
         cy.get('a#delete-contact').contains('Delete Contact').click();
@@ -280,7 +279,7 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
 
         cy.get('button#delete').contains('Delete').click({force: true});
         cy.location().should((loc) => {
-          expect(loc.pathname).to.eq('/providers/datacite/contacts');
+          expect(loc.pathname).to.eq('/providers/' + provider_id + '/contacts');
         });
       });
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -169,10 +169,10 @@ Cypress.Commands.add("createContact", (email, given_name, family_name, roles, ty
   });
 })
 
-Cypress.Commands.add("deleteProviderTestContacts", (provider, api_url, jwt) => {
+Cypress.Commands.add("deleteProviderTestContacts", (provider, test_contact_family_name_prefix, api_url, jwt) => {
   return cy.request({
     method: 'GET',
-    url: api_url + '/contacts?page[size]=500&provider-id=' + provider,
+    url: api_url + '/contacts?page[size]=1000&provider-id=' + provider + "&query=family_name:" + test_contact_family_name_prefix + "*",
     headers: {
       authorization: 'Bearer ' + jwt,
     },
@@ -196,8 +196,7 @@ Cypress.Commands.add("deleteProviderTestContacts", (provider, api_url, jwt) => {
     };
 
     const contacts = response.body.data
-    const regex = /(?:Smith|Doe)\d*/
-    const contact_ids = contacts.filter(obj => regex.test(obj.attributes.familyName)).map(obj => obj.id)
+    const contact_ids = contacts.map(obj => obj.id)
 
     deleteContactsByIds(contact_ids).then(responses => {
       return responses

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -168,3 +168,33 @@ Cypress.Commands.add("createContact", (email, given_name, family_name, roles, ty
     return(response.body.data.id);
   });
 })
+
+Cypress.Commands.add("deleteProviderContacts", (provider, api_url, jwt) => {
+  return cy.request({
+    method: 'GET',
+    url: api_url + '/providers/' + provider
+  }).then((response) => {
+    expect(response.status).to.eq(200)
+
+    const deleteContactsByIds = async (contact_ids) => {
+      const requests = contact_ids.map(contact_id =>
+        cy.request({
+          method: 'DELETE',
+          url: api_url + '/contacts/' + contact_id,
+          headers: {
+            authorization: 'Bearer ' + jwt,
+          },
+          failOnStatusCode: true,
+        })
+      );
+      const responses = await Promise.all(requests.map(request => request.then(response => response)))
+      return responses
+    };
+
+    const contacts = response.body.data.relationships.contacts.data;
+    const contact_ids = contacts.map(obj => obj.id)
+    deleteContactsByIds(contact_ids).then(responses => {
+      return responses
+    });
+  });
+})


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Instead of leaving contacts in the staging system that are created for Cypress tests, this PR removes test contacts after tests are run. 

closes: #752

## Approach
<!--- _How does this change address the problem?_ -->

Contacts are created with a specific patten in the `familyName` attribute. After tests are completed, a Cypress command is run that searches the API for these contacts and deletes them. This does not remove them completely from the database, so the random integer range appended to `familyName` was extended to reduce collisions.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
