### PR TITLE
Selecting tabs consistently moves caret when logged in as a Member or Repository

### DIFF
--- a/app/templates/providers/show.hbs
+++ b/app/templates/providers/show.hbs
@@ -60,69 +60,45 @@
         @stacked={{false}}
         @fill={{false}} as |nav|
       >
-        <nav.item>
-          <nav.link-to
-            @route="providers.show.index"
-            model="model.id"
-            class="nav-link"
-          >
-            Info
-          </nav.link-to>
-        </nav.item>
-        <nav.item>
-          <nav.link-to
-            @route="providers.show.settings"
-            model="model.id"
-            class="nav-link"
-          >
-            Settings
-          </nav.link-to>
-        </nav.item>
+        {{#link-to route='providers.show.index' tagName="li" model=model.id}}
+            {{#link-to route='providers.show.index' class='nav-link'}}
+                Info
+            {{/link-to}}
+        {{/link-to}}
+        {{#link-to route='providers.show.settings' tagName="li" model=model.id}}
+            {{#link-to route='providers.show.settings' class='nav-link'}}
+                Settings
+            {{/link-to}}
+        {{/link-to}}
         {{#if (eq model.memberType 'consortium')}}
-          <nav.item>
-            <nav.link-to @route="providers.show.organizations" class="nav-link">
-              Consortium Organizations
-            </nav.link-to>
-          </nav.item>
+          {{#link-to route='providers.show.organizations' tagName="li"}}
+              {{#link-to route='providers.show.organizations' class='nav-link'}}
+                  Consortium Organizations
+              {{/link-to}}
+          {{/link-to}}
         {{/if}}
         {{#if (not-eq model.memberType 'developer')}}
-          <nav.item>
-            <nav.link-to
-              @route="providers.show.contacts"
-              model="model.id"
-              class="nav-link"
-            >
-              Contacts
-            </nav.link-to>
-          </nav.item>
+          {{#link-to route='providers.show.contacts' tagName="li" model=model.id}}
+              {{#link-to route='providers.show.contacts' class='nav-link'}}
+                  Contacts
+              {{/link-to}}
+          {{/link-to}}
           {{#if (not-eq model.memberType 'member_only')}}
-            <nav.item>
-              <nav.link-to
-                @route="providers.show.repositories"
-                model="model.id"
-                class="nav-link"
-              >
-                Repositories
-              </nav.link-to>
-            </nav.item>
-            <nav.item>
-              <nav.link-to
-                @route="providers.show.prefixes"
-                model="model.id"
-                class="nav-link"
-              >
-                Prefixes
-              </nav.link-to>
-            </nav.item>
-            <nav.item>
-              <nav.link-to
-                @route="providers.show.dois"
-                model="model.id"
-                class="nav-link"
-              >
-                DOIs
-              </nav.link-to>
-            </nav.item>
+            {{#link-to route='providers.show.repositories' tagName="li" model=model.id}}
+                {{#link-to route='providers.show.repositories' class='nav-link'}}
+                    Repositories
+                {{/link-to}}
+            {{/link-to}}
+            {{#link-to route='providers.show.prefixes' tagName="li" model=model.id}}
+                {{#link-to route='providers.show.prefixes' class='nav-link'}}
+                    Prefixes
+                {{/link-to}}
+            {{/link-to}}
+            {{#link-to route='providers.show.dois' tagName="li" model=model.id}}
+                {{#link-to route='providers.show.dois' class='nav-link'}}
+                    DOIs
+                {{/link-to}}
+            {{/link-to}}
           {{/if}}
         {{/if}}
       </BsNav>

--- a/app/templates/repositories/show.hbs
+++ b/app/templates/repositories/show.hbs
@@ -76,45 +76,26 @@
           @stacked={{false}}
           @fill={{false}} as |nav|
         >
-          <nav.item>
-            <nav.link-to
-              @route="repositories.show.index"
-              model="model.id"
-              class="nav-link"
-              @query={{hash assignedPrefix=null}}
-            >
-              Info
-            </nav.link-to>
-          </nav.item>
-          <nav.item>
-            <nav.link-to
-              @route="repositories.show.settings"
-              model="model.id"
-              class="nav-link"
-            >
-              Settings
-            </nav.link-to>
-          </nav.item>
-          <nav.item>
-            <nav.link-to
-              @route="repositories.show.prefixes"
-              model="model.id"
-              class="nav-link"
-              @query={{hash assignedPrefix=null}}
-            >
-              Prefixes
-            </nav.link-to>
-          </nav.item>
-          <nav.item>
-            <nav.link-to
-              @route="repositories.show.dois"
-              model="model.id"
-              class="nav-link"
-              @query={{hash assignedPrefix=null}}
-            >
-              DOIs
-            </nav.link-to>
-          </nav.item>
+          {{#link-to route='repositories.show.index' tagName="li" model=model.id}}
+              {{#link-to route='repositories.show.index' class='nav-link' query=assignedPrefix}}
+                  Info
+              {{/link-to}}
+          {{/link-to}}
+          {{#link-to route='repositories.show.settings' tagName="li" model=model.id}}
+              {{#link-to route='repositories.show.settings' class='nav-link' query=assignedPrefix}}
+                  Settings
+              {{/link-to}}
+          {{/link-to}}
+          {{#link-to route='repositories.show.prefixes' tagName="li" model=model.id}}
+              {{#link-to route='repositories.show.prefixes' class='nav-link' query=assignedPrefix}}
+                  Prefixes
+              {{/link-to}}
+          {{/link-to}}
+          {{#link-to route='repositories.show.dois' tagName="li" model=model.id}}
+              {{#link-to route='repositories.show.dois' class='nav-link' query=assignedPrefix}}
+                  DOIs
+              {{/link-to}}
+          {{/link-to}}
         </BsNav>
       </div>
     </div>


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Selecting tabs now consistently moves caret when logged in as a Member or Repository. 

closes: #756 

## Approach
<!--- _How does this change address the problem?_ -->

While the containing `<a>` elements in the BsNav received the necessary `active` class, the `<li>` element did not unless the page was refreshed. This appears to be a known issue with ember-bootstrap and Bootstrap 4/5: https://www.ember-bootstrap.com/api/classes/Components.Nav.html This PR implements a workaround discussed here using curly braced `link-to` template objects: https://discuss.emberjs.com/t/bootstrap-active-links-and-lis/5018 

No changes were made to the Admin template because the active tab selection works appropriately in this view.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
