### PR TITLE
Lowercases URL subdirectory identifiers before retrieving data from lupo

### DIFF
--- a/app/routes/dois/show.js
+++ b/app/routes/dois/show.js
@@ -8,7 +8,7 @@ export default Route.extend({
   model(params) {
     // let self = this;
     return this.store
-      .findRecord('doi', params.doi_id, {
+      .findRecord('doi', params.doi_id.toLowerCase(), {
         include: 'client',
         adapterOptions: {
           affiliation: true

--- a/app/routes/providers/show.js
+++ b/app/routes/providers/show.js
@@ -12,7 +12,7 @@ export default Route.extend({
   model(params) {
     let self = this;
     return this.store
-      .findRecord('provider', params.provider_id, {
+      .findRecord('provider', params.provider_id.toLowerCase(), {
         include: 'consortium,consortium-organizations,contacts'
       })
       .then(function (provider) {

--- a/app/routes/repositories/show.js
+++ b/app/routes/repositories/show.js
@@ -11,7 +11,7 @@ export default Route.extend({
     let self = this;
 
     return this.store
-      .findRecord('repository', params.repository_id, { include: 'provider,prefixes' })
+      .findRecord('repository', params.repository_id.toLowerCase(), { include: 'provider,prefixes' })
       .then(function (repository) {
         self.headData.set('title', repository.name);
         self.headData.set('description', repository.description);

--- a/cypress/e2e/client_admin/doi.test.ts
+++ b/cypress/e2e/client_admin/doi.test.ts
@@ -468,4 +468,28 @@ describe('ACCEPTANCE: CLIENT_ADMIN | DOIS', () => {
       });
     });
   });
+
+  it('visiting specific doi with uppercase identifier in URL subdirectory', () => {
+    cy.getCookie('_jwt').then((cookie) => {
+
+      // Create a doi to be visited.
+      cy.createDoi(prefix, Cypress.env('api_url'), cookie.value).then((id) => {
+        cy.log('DOI: ' + id);
+        const uri = 'dois/' +  encodeURIComponent(id).toUpperCase() + '/edit';
+        const target_uri = '/dois/' +  encodeURIComponent(id);
+
+        cy.visit(uri);
+        cy.url().should('include', uri);
+      });
+    });
+  });
+
+  it('can see dois when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/repositories/DATACITE.TEST/dois');
+    cy.url().should('include', '/repositories/DATACITE.TEST/dois').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No DOIs found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/client_admin/info.test.ts
+++ b/cypress/e2e/client_admin/info.test.ts
@@ -9,6 +9,7 @@ function escapeRE(string) {
 describe('ACCEPTANCE: CLIENT_ADMIN | INFO', () => {
   const waitTime = 1000;
   const waitTime2 = 2000;
+  const waitTime3 = 3000;
 
   before(function () {
     cy.login(Cypress.env('client_admin_username'), Cypress.env('client_admin_password'));
@@ -173,6 +174,16 @@ describe('ACCEPTANCE: CLIENT_ADMIN | INFO', () => {
 
     cy.on("url:changed", (newUrl) => {
       expect(newUrl).to.contain("/repositories/datacite.test");
+    });
+  });
+
+  it.only('can see info when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/repositories/DATACITE.TEST');
+    cy.url().should('include', '/repositories/DATACITE.TEST').then(() => {
+      
+      cy.wait(waitTime3)
+      // Info page should be populated with non-zero graph data.
+      cy.get('.graphs > a').contains(/^0$/).should('not.exist')
     });
   });
 });

--- a/cypress/e2e/client_admin/prefixes.test.ts
+++ b/cypress/e2e/client_admin/prefixes.test.ts
@@ -78,4 +78,13 @@ describe('ACCEPTANCE: CLIENT_ADMIN | PREFIXES', () => {
       });
     });
   });
+
+  it('can see prefixes when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/repositories/DATACITE.TEST/prefixes');
+    cy.url().should('include', '/repositories/DATACITE.TEST/prefixes').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No prefixes found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/client_admin/settings.test.ts
+++ b/cypress/e2e/client_admin/settings.test.ts
@@ -75,4 +75,13 @@ describe('ACCEPTANCE: CLIENT_ADMIN | SETTINGS', () => {
         cy.get('h5').contains(/Domain/i);      });
     });
   });
+
+  it('can see settings when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/repositories/DATACITE.TEST/settings');
+    cy.url().should('include', '/repositories/DATACITE.TEST/settings').then(() => {
+
+      // Settings page should be populated.
+      cy.get('div.panel-body').contains('DATACITE.TEST');
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/contact.test.ts
+++ b/cypress/e2e/consortium_admin/contact.test.ts
@@ -286,4 +286,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONTACTS', () => {
     cy.get('.alert').contains("New repositories can't be created because you have not provided the")
     cy.get('.alert').contains("After adding contacts, please assign roles in the")
   });
+
+  it('can see contacts when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + consortium_id.toUpperCase() + '/contacts');
+    cy.url().should('include', '/providers/' + consortium_id.toUpperCase() + '/contacts').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No contacts found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/doi.test.ts
+++ b/cypress/e2e/consortium_admin/doi.test.ts
@@ -86,4 +86,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | DOIS', () => {
       cy.get('.create-doi-button').should('not.exist');    
     });
   });
+
+  it('can see dois when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/DC/dois');
+    cy.url().should('include', '/providers/DC/dois').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No DOIs found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/info.test.ts
+++ b/cypress/e2e/consortium_admin/info.test.ts
@@ -8,7 +8,8 @@ function escapeRE(string) {
 describe('ACCEPTANCE: CONSORTIUM_ADMIN | INFO', () => {
   const waitTime = 1000;
   const waitTime2 = 2000;
-
+  const waitTime3 = 3000;
+  
   before(function () {
     cy.login(Cypress.env('consortium_admin_username'), Cypress.env('consortium_admin_password'));
     cy.setCookie('_consent', 'true');
@@ -198,6 +199,16 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | INFO', () => {
 
     cy.on("url:changed", (newUrl) => {
       expect(newUrl).to.contain("/providers/dc");
+    });
+  });
+
+  it.only('can see info when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/DC');
+    cy.url().should('include', '/providers/DC').then(() => {
+      
+      cy.wait(waitTime3)
+      // Info page should be populated with non-zero graph data.
+      cy.get('.graphs > a').contains(/^0$/).should('not.exist')
     });
   });
 });

--- a/cypress/e2e/consortium_admin/organizations.test.ts
+++ b/cypress/e2e/consortium_admin/organizations.test.ts
@@ -120,4 +120,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | CONSORTIUM ORGANIZATIONS', () => {
       });
     });
   });
+
+  it('can see consortium organizations when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/DC/organizations');
+    cy.url().should('include', '/providers/DC/organizations').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No consortium organizations found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/prefixes.test.ts
+++ b/cypress/e2e/consortium_admin/prefixes.test.ts
@@ -75,4 +75,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | PREFIXES', () => {
       cy.get('.create-doi-button').should('not.exist');    
     });
   });
+
+  it('can see prefixes when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/DC/prefixes');
+    cy.url().should('include', '/providers/DC/prefixes').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No prefixes found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/repositories.test.ts
+++ b/cypress/e2e/consortium_admin/repositories.test.ts
@@ -124,4 +124,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | REPOSITORIES', () => {
     // Create DOI button
     cy.get('.create-doi-button').should('not.exist');    
   });
+
+  it('can see repositories when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + consortium_id.toUpperCase() + '/repositories');
+    cy.url().should('include', '/providers/' + consortium_id.toUpperCase() + '/repositories').then(() => {
+
+      // Repositories page should be populated.
+      cy.contains('No repositories found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/consortium_admin/settings.test.ts
+++ b/cypress/e2e/consortium_admin/settings.test.ts
@@ -125,4 +125,13 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | SETTINGS', () => {
       cy.get('.create-doi-button').should('not.exist');    
     });
   });
+
+  it('can see settings when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + consortium_id.toUpperCase() + '/settings');
+    cy.url().should('include', '/providers/' + consortium_id.toUpperCase() + '/settings').then(() => {
+
+      // Settings page should be populated.
+      cy.get('div.panel-body').contains(Cypress.env('consortium_admin_username').toUpperCase());
+    });
+  });
 });

--- a/cypress/e2e/organization_admin/contact.test.ts
+++ b/cypress/e2e/organization_admin/contact.test.ts
@@ -295,4 +295,13 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | CONTACTS', () => {
     cy.get('h3.member-results').contains('Contact Information');
     cy.get('[cy-data="service"]').should('exist');
   });
+
+  it('can see contacts when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + provider_id.toUpperCase() + '/contacts');
+    cy.url().should('include', '/providers/' + provider_id.toUpperCase() + '/contacts').then(() => {
+
+      // Prefix page should be populated.
+      cy.contains('No contacts found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/organization_admin/doi.test.ts
+++ b/cypress/e2e/organization_admin/doi.test.ts
@@ -81,5 +81,14 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | DOIS', () => {
         cy.get('.create-doi-button').should('not.exist');
       });
     });
+
+    it('can see dois when using capitalized identifier URL subdirectory', () => {
+      cy.visit('/providers/DATACITE/dois');
+      cy.url().should('include', '/providers/DATACITE/dois').then(() => {
+  
+        // Prefix page should be populated.
+        cy.contains('No DOIs found.').should('not.exist')
+      });
+    });
   });
   

--- a/cypress/e2e/organization_admin/info.test.ts
+++ b/cypress/e2e/organization_admin/info.test.ts
@@ -8,6 +8,7 @@ function escapeRE(string) {
 describe('ACCEPTANCE: ORGANIZATION_ADMIN | INFO', () => {
   const waitTime = 1000;
   const waitTime2 = 2000;
+  const waitTime3 = 3000;
 
   before(function () {
     cy.login(Cypress.env('organization_admin_username'), Cypress.env('organization_admin_password'));
@@ -174,6 +175,16 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | INFO', () => {
     });
     cy.on("url:changed", (newUrl) => {
       expect(newUrl).to.contain("/providers/datacite");
+    });
+  });
+
+  it.only('can see info when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/DATACITE');
+    cy.url().should('include', '/providers/DATACITE').then(() => {
+      
+      cy.wait(waitTime3)
+      // Info page should be populated with non-zero graph data.
+      cy.get('.graphs > a').contains(/^0$/).should('not.exist')
     });
   });
 });

--- a/cypress/e2e/organization_admin/prefixes.test.ts
+++ b/cypress/e2e/organization_admin/prefixes.test.ts
@@ -74,5 +74,14 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | PREFIXES', () => {
         cy.get('.create-doi-button').should('not.exist');
       });
     });
+
+    it('can see prefixes when using capitalized identifier URL subdirectory', () => {
+      cy.visit('/providers/DATACITE/prefixes');
+      cy.url().should('include', '/providers/DATACITE/prefixes').then(() => {
+
+        // Prefix page should be populated.
+        cy.contains('No prefixes found.').should('not.exist')
+      });
+    });
   });
   

--- a/cypress/e2e/organization_admin/repositories.test.ts
+++ b/cypress/e2e/organization_admin/repositories.test.ts
@@ -226,4 +226,13 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | REPOSITORIES', () => {
     // Create DOI button
     cy.get('.create-doi-button').should('not.exist');
   });
+
+  it('can see repositories when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + provider_id.toUpperCase() + '/repositories');
+    cy.url().should('include', '/providers/' + provider_id.toUpperCase() + '/repositories').then(() => {
+
+      // Repositories page should be populated.
+      cy.contains('No repositories found.').should('not.exist')
+    });
+  });
 });

--- a/cypress/e2e/organization_admin/settings.test.ts
+++ b/cypress/e2e/organization_admin/settings.test.ts
@@ -129,4 +129,13 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | SETTINGS', () => {
       cy.get('.create-doi-button').should('not.exist');
     });
   });
+
+  it('can see settings when using capitalized identifier URL subdirectory', () => {
+    cy.visit('/providers/' + provider_id.toUpperCase() + '/settings');
+    cy.url().should('include', '/providers/' + provider_id.toUpperCase() + '/settings').then(() => {
+
+      // Settings page should be populated.
+      cy.get('div.panel-body').contains(Cypress.env('organization_admin_username').toUpperCase());
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Previously, Fabrica would display different data when provider or consortium identifier in URL subdirectory was upper or lowercase. In Ember v3.24, this occasionally caused issues where the Ember model id would be different than the id retrieved from the store. This PR alters the routes for case-sensitive identifiers (providers, repositories, and DOIs) so that the created Ember model consistently has a lowercase identifier. 

VERCEL DEPLOYMENT: https://bracco-d4hs1htbw-datacite.vercel.app/

closes: #770 

## Approach
<!--- _How does this change address the problem?_ -->

Changes the routes for providers, repositories, and DOIs so that the identifier in the URL subdirectory/parameter is lowercased before the relevant record is retrieved. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
