### PR TITLE
Improve Cypress test contact deletion reliability

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -189,7 +189,7 @@ Cypress.Commands.add("createContact", (email, given_name, family_name, roles, ty
 Cypress.Commands.add("deleteProviderTestContacts", (provider, test_contact_family_name_prefix, api_url, jwt) => {
   return cy.request({
     method: 'GET',
-    url: api_url + '/contacts?page[size]=1000&provider-id=' + provider + "&query=family_name:" + test_contact_family_name_prefix + "*",
+    url: api_url + '/contacts?page[size]=1000&provider-id=' + provider + "&query=email:*" + test_contact_family_name_prefix + "*",
     headers: {
       authorization: 'Bearer ' + jwt,
     },


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Some Cypress test contacts appear to be created without a `family_name` and thus are not swept up by the query in `deleteProviderTestContacts`, which relies on this field. Because the `email` field consistently exists, this PR changes the query to this field. 

closes: #771 

## Approach
<!--- _How does this change address the problem?_ -->

Updates lupo query to `/contacts` endpoint for `deleteProviderTestContacts` method. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
