### PR TITLE
Edit doi forms weren't working due to date validation problem.

### DIFF
--- a/app/models/doi.js
+++ b/app/models/doi.js
@@ -90,10 +90,9 @@ const Validations = buildValidations({
       })
     }),
     validator('date', {
-      //after: '999',
-      after: '999',
-      before: computed('model.maxMintFutureOffset', function () {
-        let mydate =  (new Date().getFullYear() + Number(this.model.get('maxMintFutureOffset')) + 1).toString();
+      onOrAfter: '1000',
+      onOrBefore: computed('model.maxMintFutureOffset', function () {
+        let mydate = (new Date().getFullYear() + Number(this.model.get('maxMintFutureOffset'))).toString();
         return mydate;
       }),
       precision: 'year',


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #803

## Approach
<!--- _How does this change address the problem?_ -->

Interpreting a non-standard format date was causing an error in Firefox.  It was expecting 'YYYY' and was given '999'.  '0999' works in Chrome, Firefox, and Safari.  

I also changed the conditions to use 'onOrBefore' and 'onOrAfter' instead of 'Before' and 'After'.  I think this helps the code to be a little more understandable.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
