### PR TITLE
doi forms weren't showing validation error for funderName when not draft

### DIFF
--- a/app/models/funding-reference.js
+++ b/app/models/funding-reference.js
@@ -9,8 +9,8 @@ const Validations = buildValidations({
     validator('presence', {
       presence: true,
       message: 'Funder Name must be included if you input a funderIdentifier.',
-      disabled: computed('model.funderIdentifier', function () {
-        return isBlank(this.model.get('funderIdentifier'));
+      disabled: computed('model.{funderIdentifier,state}', function () {
+        return this.model.get('state') === 'draft'
       })
     })
   ],


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #729 

## Approach
<!--- _How does this change address the problem?_ -->
Currently we disable the validation on `funderName` when `funderIdentifier`. However, `funderIdentifier` is added automatically when you select `funderName`. Solution is to disable the validation only when the doi is in draft state

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
