### PR TITLE
Remove default schemaURI when subject is custom 

### DIFF
--- a/app/components/doi-subject.js
+++ b/app/components/doi-subject.js
@@ -76,8 +76,7 @@ export default Component.extend({
       } else {
         this.fragment.set('subject', value);
         this.setScheme(null);
-        this.set('schemeUri', null);
-        this.fragment.set('subjectSchemeUri', null);
+        this.setSchemeUri(null);
         this.setClassificationCode(null);
         this.set('oecdSelected', false);
       }

--- a/app/models/subject.js
+++ b/app/models/subject.js
@@ -17,7 +17,7 @@ export default Fragment.extend(Validations, {
   subject: attr('string'),
   subjectScheme: attr('string', { defaultValue: null }),
   schemeUri: attr('string', { defaultValue: null }),
-  valueUri: attr('string', { defaultValue: "" }),
+  valueUri: attr('string', { defaultValue: null }),
   classificationCode: attr('string', { defaultValue: null }),
   lang: attr('string', { defaultValue: null }),
   subjectSchemeUri: computed('schemeUri', function () {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Adding and then replacing an OECD subject in the Fabrica form does not remove OECD schemeURI and valueURI from resulting metadata

closes: #646 

## Approach
<!--- _How does this change address the problem?_ -->
- set schemaURI to null when fos is empty

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
