### PR TITLE
Fix crash from inconsistent browser state while display a flash message

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -31,6 +31,9 @@ export default Route.extend({
 
       let self = this;
       this.prefixes.available().then(function(value) {
+        if (self.get('flashMessages').isDestroying || self.get('flashMessages').isDestroyed) {
+          return;
+        }
         if (value <= 0) {
           self.get('flashMessages').danger(self.prefixes.msg_zero);
         } else if (value < self.prefixes.min) {

--- a/app/routes/providers/show.js
+++ b/app/routes/providers/show.js
@@ -33,6 +33,9 @@ export default Route.extend({
     if (this.get('currentUser.role_id') === 'staff_admin') {
       let self = this;
       this.prefixes.available().then(function(value) {
+        if (self.get('flashMessages').isDestroying || self.get('flashMessages').isDestroyed) {
+          return;
+        }
         if (value <= 0) {
           self.get('flashMessages').danger(self.prefixes.msg_zero);
         } else if (value < self.prefixes.min) {

--- a/cypress/e2e/organization_admin/info.test.ts
+++ b/cypress/e2e/organization_admin/info.test.ts
@@ -182,9 +182,9 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | INFO', () => {
     cy.visit('/providers/DATACITE');
     cy.url().should('include', '/providers/DATACITE').then(() => {
       
-      cy.wait(6000)
+      cy.wait(waitTime3)
       // Info page should be populated with non-zero graph data.
-      cy.get('.graphs > a').contains(/^0$/).should('not.exist')
+      cy.get('.graphs > a').contains(/^[0-9]+$/).should('exist')
     });
   });
 });

--- a/cypress/e2e/organization_admin/info.test.ts
+++ b/cypress/e2e/organization_admin/info.test.ts
@@ -182,7 +182,7 @@ describe('ACCEPTANCE: ORGANIZATION_ADMIN | INFO', () => {
     cy.visit('/providers/DATACITE');
     cy.url().should('include', '/providers/DATACITE').then(() => {
       
-      cy.wait(waitTime3)
+      cy.wait(6000)
       // Info page should be populated with non-zero graph data.
       cy.get('.graphs > a').contains(/^0$/).should('not.exist')
     });


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #820

Fabrica crashes due to inconsistent state - mostly seen during development.

## Approach
<!--- _How does this change address the problem?_ -->

Checks to make sure the flashmessages object is not being destroyed before trying to set it.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
