### PR TITLE
Fix for syntax error that broke a link on the sign-in page.

### DIFF
--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import { inject as service } from '@ember/service';
-i
+
 export default Route.extend(UnauthenticatedRouteMixin, {
   router: service(),
 

--- a/app/templates/sign-in.hbs
+++ b/app/templates/sign-in.hbs
@@ -27,7 +27,7 @@
               {{/if}}
 
               <div><!-- need a fix here -->
-                <!-- <LinkTo @route="reset">Forgot password?</LinkTo> •  -->
+                <LinkTo @route="reset">Forgot password?</LinkTo> • 
                 <a target="_blank" rel="noopener" href={{get (links) "CREATE_A_FABRICA_ACCOUNT_URL" }}>Need an account?</a>
               </div>
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fix typo that broke the 'forgot password' link on the sign-in page.

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
