### PR TITLE
Fix for Fabrica form resets selected prefix when entering metadata

### DIFF
--- a/app/components/doi-doi.js
+++ b/app/components/doi-doi.js
@@ -23,7 +23,7 @@ export default Component.extend({
 
   repositoryPrefixes: null,
 
-  didReceiveAttrs() {
+  init() {
     this._super(...arguments);
 
     this.setDefaultPrefix();
@@ -104,6 +104,7 @@ export default Component.extend({
 
   actions: {
     selectPrefix(repositoryPrefix) {
+      console.log("SELECT PREFIX")
       this.model.set('prefix', repositoryPrefix.prefix.get('id'));
       this.model.set(
         'doi',

--- a/app/components/doi-doi.js
+++ b/app/components/doi-doi.js
@@ -104,7 +104,6 @@ export default Component.extend({
 
   actions: {
     selectPrefix(repositoryPrefix) {
-      console.log("SELECT PREFIX")
       this.model.set('prefix', repositoryPrefix.prefix.get('id'));
       this.model.set(
         'doi',

--- a/cypress/e2e/staff_admin/contact.test.ts
+++ b/cypress/e2e/staff_admin/contact.test.ts
@@ -52,12 +52,13 @@ describe('ACCEPTANCE: STAFF_ADMIN | CONTACTS', () => {
 
     cy.getCookie('_jwt').then((cookie) => {
       cy.createContact(email, given_name, family_name, roles, type, provider_id, Cypress.env('api_url'), cookie.value).then((id) => {
+        cy.wait(waitTime4)
         cy.log('CREATED CONTACT: ' + given_name + ' ' + family_name + ' (' + id + ')');
 
         // Give it a little extra time to process the new contact so that we can search for it.
         cy.visit('/contacts');
         cy.url().should('include', '/contacts')
-        cy.wait(waitTime)
+        cy.wait(waitTime4)
 
         cy.get('input[name="query"]')
           .type(family_name + '{enter}', { force: true } )


### PR DESCRIPTION

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fix for Fabrica form resets selected prefix when entering metadata

closes: #864

## Approach
<!--- _How does this change address the problem?_ -->

Change `didReceiveAttrs` lifecycle hook to `init` so `setDefaultPrefix` is only called when the form loads.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
