### PR TITLE
Change email fields to use email control type

### DIFF
--- a/app/templates/providers/new.hbs
+++ b/app/templates/providers/new.hbs
@@ -188,7 +188,7 @@
             <el.control id="group-email-field" />
           </form.element>
           <form.element
-            @controlType="email"
+            @controlType="text"
             id="website"
             class="form-group"
             @label="Website (optional)"

--- a/app/templates/providers/new.hbs
+++ b/app/templates/providers/new.hbs
@@ -168,7 +168,7 @@
             {{/if}}
           {{/if}}
           <form.element
-            @controlType="text"
+            @controlType="email"
             id="system-email"
             class="form-group"
             @label="System Email"
@@ -178,7 +178,7 @@
             <el.control id="system-email-field" />
           </form.element>
           <form.element
-            @controlType="text"
+            @controlType="email"
             id="group-email"
             class="form-group"
             @label="Group Email (optional)"
@@ -188,7 +188,7 @@
             <el.control id="group-email-field" />
           </form.element>
           <form.element
-            @controlType="text"
+            @controlType="email"
             id="website"
             class="form-group"
             @label="Website (optional)"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
When creating a new provider, the email fields return an error if you accidentally have a whitespace at the end of the email (e.g if you copied/pasted it from somewhere) and don't just trim it automatically, even when the rest of the email is valid.

This issue doesn't happen on the repository creation page, which automatically trims the email field of whitespace.

Both use the same validator:
https://github.com/datacite/bracco/blob/main/app/models/repository.js#L123
https://github.com/datacite/bracco/blob/main/app/models/provider.js#L93

But are using different control types:
https://github.com/datacite/bracco/blob/main/app/templates/repositories/show/edit.hbs#L40
https://github.com/datacite/bracco/blob/main/app/templates/providers/new.hbs#L170-L172

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->
Update the field type to use the email field rather than text

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
