### PR TITLE
Explicitly set the default doi sorting parameter

### DIFF
--- a/app/controllers/repositories/show/dois/index.js
+++ b/app/controllers/repositories/show/dois/index.js
@@ -39,11 +39,11 @@ export default class EditController extends Controller {
   state = null;
   source = null;
   'link-check-status' = null;
-  sort = null;
+  sort = '-updated';
   'schema-version' = null;
   certificate = null;
   page = 1;
   size = 25;
   affiliation = true;
   publisher = true;
-};
+}

--- a/app/routes/dois/index.js
+++ b/app/routes/dois/index.js
@@ -28,7 +28,8 @@ export default class IndexRoute extends Route {
         number: params.page,
         size: params.size
       },
-      include: 'client'
+      include: 'client',
+      sort: params.sort || '-updated'
     });
 
     return this.store


### PR DESCRIPTION
Explicitly sets the default doi sorting parameter, previously this was implicitly set by passing a null or blank sort parameter to the REST API.

This is important if we ever want to change the default sorting parameter (such as in datacite/lupo/pull/1272)

## Approach
Sets the default to '-updated' instead of null in relevant controllers/routes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
