### PR TITLE
Y2k-type bug in test

### DIFF
--- a/cypress/e2e/consortium_admin/info.test.ts
+++ b/cypress/e2e/consortium_admin/info.test.ts
@@ -208,7 +208,8 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | INFO', () => {
       
       cy.wait(waitTime3)
       // Info page should be populated with non-zero graph data.
-      cy.get('.graphs > a').contains(/^0$/).should('not.exist')
+      // cy.get('.graphs > a').contains(/^0$/).should('not.exist')
+      cy.get('.graphs > a').should('have.length', 3)
     });
   });
 });

--- a/cypress/e2e/consortium_admin/info.test.ts
+++ b/cypress/e2e/consortium_admin/info.test.ts
@@ -202,13 +202,12 @@ describe('ACCEPTANCE: CONSORTIUM_ADMIN | INFO', () => {
     });
   });
 
-  it('can see info when using capitalized identifier URL subdirectory', () => {
+  it('can see info page when using capitalized identifier URL subdirectory', () => {
     cy.visit('/providers/DC');
     cy.url().should('include', '/providers/DC').then(() => {
       
       cy.wait(waitTime3)
-      // Info page should be populated with non-zero graph data.
-      // cy.get('.graphs > a').contains(/^0$/).should('not.exist')
+      // Info page should be populated with 3 graphs.
       cy.get('.graphs > a').should('have.length', 3)
     });
   });


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #917

## Approach
<!--- _How does this change address the problem?_ -->

Remove testing for specific numbers in the info tab for cypress/e2e/consortium_admin/info.test.ts.  This always breaks after the New Year.  Test only that there are 3 graphs on the page.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
