### PR TITLE
Trim identification string before authentication

### DIFF
--- a/app/controllers/sign-in.js
+++ b/app/controllers/sign-in.js
@@ -29,6 +29,7 @@ export default class SignInController extends Controller {
   authenticate() {
     let self = this;
     let { identification, password } = this;
+    identification = identification.trim();
     this.session
       .authenticate('authenticator:oauth2', identification, password)
       .then(() => {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Trims the identification string before authentication to avoid issues with whitespace described in the issue below:

closes: https://github.com/datacite/bracco/issues/642

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
