### PR TITLE
Fix publisher and numberType in relatedItems.

### DIFF
--- a/app/models/related-item.js
+++ b/app/models/related-item.js
@@ -128,7 +128,10 @@ export default class RelatedItem extends Fragment.extend(Validations) {
   @attr('string', { defaultValue: null })
   lastPage;
 
-  @fragment('publisher')
+  @attr('string', { defaultValue: null })
+  numberType;
+
+  @attr('string', { defaultValue: null })
   publisher;
 
   @attr('string', { defaultValue: null })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bracco",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "private": true,
   "description": "Fabrica",
   "repository": {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fix for 2 problems in relatedItems - relatedItems.publisher and relatedItems.numbertype values are not preserved after saving the doi with the Fabrica update form.

closes: none

## Approach
<!--- _How does this change address the problem?_ -->

3 possibilities: 1) the values are not received from the API, 2) there is something wrong in the Fabrica model, or 3) there is a problem in the serializer.  It turns out there was a problem in the model.  relatedItems.publisher should have been a string, and not a fragment.  relatedItems.numbertype was not in the model at all.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
