### PR TITLE
Call facets on pages where they are required

### DIFF
--- a/app/routes/dois/index.js
+++ b/app/routes/dois/index.js
@@ -29,7 +29,12 @@ export default class IndexRoute extends Route {
         size: params.size
       },
       include: 'client',
-      sort: params.sort || '-updated'
+      sort: params.sort || '-updated',
+
+      facets:
+        'affiliations,certificates,citations,clients,created,downloads,fieldsOfScience,licenses,linkChecksStatus,prefixes,providers,published,registered,resourceTypes,schemaVersions,states,subjects,views',
+
+      'disable-facets': 'false'
     });
 
     return this.store

--- a/app/routes/providers/show/dois.js
+++ b/app/routes/providers/show/dois.js
@@ -29,7 +29,12 @@ export default class DoisRoute extends Route {
         size: params.size
       },
       'provider-id': providerId,
-      'consortium-id': consortiumId
+      'consortium-id': consortiumId,
+
+      facets:
+        'affiliations,certificates,citations,clients,created,downloads,fieldsOfScience,licenses,linkChecksStatus,prefixes,providers,published,registered,resourceTypes,schemaVersions,states,subjects,views',
+
+      'disable-facets': 'false'
     });
 
     return hash({

--- a/app/routes/repositories/show/dois/index.js
+++ b/app/routes/repositories/show/dois/index.js
@@ -20,7 +20,12 @@ export default class IndexRoute extends Route {
         number: params.page,
         size: params.size
       },
-      'client-id': this.modelFor('repositories/show').get('id')
+      'client-id': this.modelFor('repositories/show').get('id'),
+
+      facets:
+        'affiliations,certificates,citations,clients,created,downloads,fieldsOfScience,licenses,linkChecksStatus,prefixes,providers,published,registered,resourceTypes,schemaVersions,states,subjects,views',
+
+      'disable-facets': 'false'
     });
 
     return hash({

--- a/app/routes/users/show.js
+++ b/app/routes/users/show.js
@@ -30,7 +30,12 @@ export default class ShowRoute extends Route {
         number: params.page,
         size: params.size
       },
-      'user-id': `${params.user_id}`
+      'user-id': `${params.user_id}`,
+
+      facets:
+        'affiliations,certificates,citations,clients,created,downloads,fieldsOfScience,licenses,linkChecksStatus,prefixes,providers,published,registered,resourceTypes,schemaVersions,states,subjects,views',
+
+      'disable-facets': 'false'
     });
 
     // eslint-disable-next-line no-undef

--- a/app/routes/users/show/dois.js
+++ b/app/routes/users/show/dois.js
@@ -21,7 +21,12 @@ export default class DoisRoute extends Route {
         number: params.page,
         size: params.size
       },
-      'user-id': user.get('id')
+      'user-id': user.get('id'),
+
+      facets:
+        'affiliations,certificates,citations,clients,created,downloads,fieldsOfScience,licenses,linkChecksStatus,prefixes,providers,published,registered,resourceTypes,schemaVersions,states,subjects,views',
+
+      'disable-facets': 'false'
     });
 
     return hash({


### PR DESCRIPTION
https://github.com/datacite/product-backlog/issues/433 

## Summary
The DataCite API will stop returning `/dois` facet aggregations in `meta` by default. This PR updates all DOI list queries in bracco to explicitly request facets (and force-enable them) so the facet sidebar continues to work.

## Changes
- Added `facets=...` and `disable-facets=false` to `/dois` queries in:
  - Global DOIs index (`app/routes/dois/index.js`)
  - Provider DOIs (`app/routes/providers/show/dois.js`)
  - Repository DOIs (`app/routes/repositories/show/dois/index.js`)
  - User DOIs (`app/routes/users/show/dois.js`)
  - User profile page DOI meta query (`app/routes/users/show.js`)