### PR TITLE
Remove relationTypeInformation requirement from relatedItem

### DIFF
--- a/app/models/related-item.js
+++ b/app/models/related-item.js
@@ -33,18 +33,6 @@ const Validations = buildValidations({
       })
     })
   ],
-  relationTypeInformation: [
-    validator('presence', {
-      presence: true,
-      message: 'Please enter text to support the Relation Type.',
-      disabled: computed('model.{title,state}', function () {
-        return (
-          this.model.get('state') === 'draft' ||
-          isBlank(this.model.get('title'))
-        );
-      })
-    })
-  ],
   title: [
     validator('presence', {
       presence: true,


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: https://github.com/datacite/bracco/issues/947

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed overly strict validation requirement for related item information. Users can now create related items without mandatory information in this field when it's not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->