### PR TITLE
Display 'Year Registered' facet on all doi list pages

### DIFF
--- a/app/components/doi-list.hbs
+++ b/app/components/doi-list.hbs
@@ -280,10 +280,9 @@
       </div>
     </div>
   {{/if}}
+  
   {{#if
-    (and
-      (can 'source doi' this.model) (or this.model.meta.registered this.model.query.registered)
-    )
+    (or this.model.meta.registered this.model.query.registered)
   }}
     <div class="panel facets">
       <div class="panel-body">


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

status: on hold until we can resolve https://github.com/datacite/lupo/issues/1497, "Investigate accuracy of DOI facets data as returned from lupo".

closes: https://github.com/datacite/product-backlog/issues/635

preview: https://bracco-6k5h0fyjm-datacite.vercel.app/ 

## Approach
<!--- _How does this change address the problem?_ -->

Remove the access check on displaying that facet.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated visibility conditions for the Year registered panel to display whenever registration data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->