### PR TITLE
Remove focus from the button after clicking to ultimately clear the s…

### DIFF
--- a/app/components/metadata-dashboard-button.js
+++ b/app/components/metadata-dashboard-button.js
@@ -14,6 +14,7 @@ export default class MetadataDashboardButton extends Component {
 
   @action
   openLink(url) {
+    document.activeElement.blur(); // Remove focus from the button after clicking to ultimately clear the styles when the user returns to the page.
     window.open(url, '_blank', 'noopener,noreferrer');
   }
 }


### PR DESCRIPTION
…tyles when the user returns to the page.

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Allow for the metadata dashboard button styles to be cleared so that when the user returns to the page after having clicked the button, the button styles are reset to their normal state.

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
