### PR TITLE
Automatically deploy to vercel preview in the 'test pull request' git…

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}  
+    name: Deploy to Vercel Preview
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }} 
     needs: [call_build, ember_test, cypress_test]
     runs-on: ubuntu-latest
     permissions:
@@ -33,7 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Vercel deploy preview
         uses: amondnet/vercel-action@225d234cfe5340ca1f9a6cd158338126b5b6845f # v25.1.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,14 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract variables
-        shell: bash
-        run: |
-          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
-          echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "GIT_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        id: extract_variables
-
       - name: Vercel deploy staging
         uses: amondnet/vercel-action@225d234cfe5340ca1f9a6cd158338126b5b6845f # v25.1.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,3 +22,31 @@ jobs:
     needs: call_build
     uses: ./.github/workflows/cypress_test.yml
     secrets: inherit
+
+  deploy:
+    needs: [call_build, ember_test, cypress_test]
+    runs-on: ubuntu-latest
+    environment: vercel-bracco-preview
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract variables
+        shell: bash
+        run: |
+          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
+          echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "GIT_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: extract_variables
+
+      - name: Vercel deploy staging
+        uses: amondnet/vercel-action@v25.1.1
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.ORG_ID}}
+          vercel-project-id: ${{ secrets.PROJECT_ID}}
+          vercel-args: ${{ vars.VERCEL_NOCACHE  == 'true' && '--force' || '' }}  --build-env HANDLE_SERVER=${{vars.HANDLE_SERVER}}
+          scope: ${{ secrets.TEAM_ID}}
+          vercel-project-name: 'bracco'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
         id: extract_variables
 
       - name: Vercel deploy staging
-        uses: amondnet/vercel-action@v25.1.1
+        uses: amondnet/vercel-action@225d234cfe5340ca1f9a6cd158338126b5b6845f # v25.1.1
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.ORG_ID}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,11 +24,13 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}  
     needs: [call_build, ember_test, cypress_test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment: vercel-bracco-preview
     env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,6 @@ jobs:
     permissions:
       contents: read
     environment: vercel-bracco-preview
-    env:
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Vercel deploy staging
+      - name: Vercel deploy preview
         uses: amondnet/vercel-action@225d234cfe5340ca1f9a6cd158338126b5b6845f # v25.1.1
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
…hub  workflow.

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Add deploy code to the pull_request.yml github workflow in order to shorten time-to-preview for a pull request.

closes: https://github.com/datacite/bracco/issues/955

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Vercel preview deployments for pull requests that run after build and test jobs, providing immediate staging snapshots.
  * Deployments run conditionally to restrict when previews are created.
  * Previews can be forced to bypass cache and include build-time server configuration to match runtime settings.
  * Deployment progress and status are surfaced during code review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->