### PR TITLE
Remove automatic password generation

### DIFF
--- a/app/controllers/change.js
+++ b/app/controllers/change.js
@@ -32,29 +32,6 @@ export default class ChangeController extends Controller {
   }
 
   @action
-  generate() {
-    let self = this;
-    let url = ENV.API_URL + '/random';
-    fetch(url, {
-      headers: {
-        Authorization: 'Bearer ' + this.currentUser.get('jwt')
-      }
-    })
-      .then(function (response) {
-        if (response.ok) {
-          response.json().then(function (data) {
-            self.get('model').set('passwordInput', data.phrase);
-          });
-        } else {
-          console.debug(response);
-        }
-      })
-      .catch(function (error) {
-        console.debug(error);
-      });
-  }
-
-  @action
   submitAction(provider) {
     let self = this;
     provider

--- a/app/controllers/password.js
+++ b/app/controllers/password.js
@@ -54,27 +54,4 @@ export default class PasswordController extends Controller {
       self.router.transitionTo('index');
     });
   }
-
-  @action
-  generate() {
-    let self = this;
-    let url = ENV.API_URL + '/random';
-    fetch(url, {
-      headers: {
-        Authorization: 'Bearer ' + this.currentUser.get('jwt')
-      }
-    })
-      .then(function (response) {
-        if (response.ok) {
-          response.json().then(function (data) {
-            self.get('model').set('passwordInput', data.phrase);
-          });
-        } else {
-          console.debug(response);
-        }
-      })
-      .catch(function (error) {
-        console.debug(error);
-      });
-  }
 }

--- a/app/controllers/providers/show/change.js
+++ b/app/controllers/providers/show/change.js
@@ -32,29 +32,6 @@ export default class ChangeController extends Controller {
   }
 
   @action
-  generate() {
-    let self = this;
-    let url = ENV.API_URL + '/random';
-    fetch(url, {
-      headers: {
-        Authorization: 'Bearer ' + this.currentUser.get('jwt')
-      }
-    })
-      .then(function (response) {
-        if (response.ok) {
-          response.json().then(function (data) {
-            self.get('model').set('passwordInput', data.phrase);
-          });
-        } else {
-          console.debug(response);
-        }
-      })
-      .catch(function (error) {
-        console.debug(error);
-      });
-  }
-
-  @action
   submitAction() {
     let self = this;
     this.model

--- a/app/controllers/repositories/show/change.js
+++ b/app/controllers/repositories/show/change.js
@@ -32,29 +32,6 @@ export default class ChangeController extends Controller {
   }
 
   @action
-  generateAction() {
-    let self = this;
-    let url = ENV.API_URL + '/random';
-    fetch(url, {
-      headers: {
-        Authorization: 'Bearer ' + this.currentUser.get('jwt')
-      }
-    })
-      .then(function (response) {
-        if (response.ok) {
-          response.json().then(function (data) {
-            self.get('model').set('passwordInput', data.phrase);
-          });
-        } else {
-          console.debug(response);
-        }
-      })
-      .catch(function (error) {
-        console.debug(error);
-      });
-  }
-
-  @action
   submitAction(repository) {
     let self = this;
     repository

--- a/app/templates/change.hbs
+++ b/app/templates/change.hbs
@@ -8,9 +8,7 @@
       <div class="panel panel-transparent">
         <div class="panel-body">
           <div class="col-md-9 col-md-offset-3"><h3 class="edit">Set Password</h3></div>
-
-          <div class="col-md-9 col-md-offset-3"><span class="help-block">Click <a class="action-link" {{action "generate"}} data-test-password-suggestion>here</a> for a password suggestion.</span></div>
-
+          
           <BsForm @formLayout="horizontal" class="form-horizontal" @horizontalLabelGridClass="col-md-3" @model={{this.model}} @onSubmit={{action "submitAction" this.model}} @submitOnEnter={{true}} as |form|>
             <form.element @controlType="password" id="password-input" class="form-group" @property="passwordInput" @label="New Password" as |el|> <el.control id="password-input-field" /><i class="bi bi-eye-slash" id="togglePassword" {{action 'togglePassword'}}></i></form.element>
             <form.element @controlType="password" id="confirm-password-input" class="form-group" @property="confirmPasswordInput" @label="Confirm Password" as |el|> <el.control id="confirm-password-input-field" /><i class="bi bi-eye-slash" id="toggleConfirmPassword" {{action 'toggleConfirmPassword'}}></i></form.element>

--- a/app/templates/password.hbs
+++ b/app/templates/password.hbs
@@ -13,17 +13,6 @@
             <h3 class="title">
               Set Password
             </h3>
-            <span class="help-block">
-              Click
-              <a
-                class="action-link"
-                data-test-password-suggestion
-                {{action 'generate'}}
-              >
-                here
-              </a>
-              for a password suggestion.
-            </span>
             <BsForm
               @formLayout="vertical"
               @model={{this.model}}

--- a/app/templates/providers/show/change.hbs
+++ b/app/templates/providers/show/change.hbs
@@ -2,8 +2,6 @@
   <div class="panel-body">
     <div class="col-md-9 col-md-offset-3"><h3 class="edit">Set Password</h3></div>
 
-    <div class="col-md-9 col-md-offset-3"><span class="help-block">Click <a class="action-link" {{action "generate"}} data-test-password-suggestion>here</a> for a password suggestion.</span></div>
-
     <BsForm @formLayout="horizontal" class="form-horizontal" @horizontalLabelGridClass="col-md-3" @model={{this.model}} @onSubmit={{action "submitAction"}} @submitOnEnter={{true}} as |form|>
       <form.element @controlType="password" id="password-input" class="form-group" @property="passwordInput" @label="New Password" as |el| >
         <el.control id="password-input-field" /><i class="bi bi-eye-slash" id="togglePassword" {{action 'togglePassword'}}></i>

--- a/app/templates/repositories/show/change.hbs
+++ b/app/templates/repositories/show/change.hbs
@@ -2,8 +2,6 @@
     <div class="panel-body">
       <div class="col-md-9 col-md-offset-3">
         <h3 class="edit">Set Password</h3>
-
-        <span class="help-block">Click <a class="action-link" {{action "generateAction"}} data-test-password-suggestion>here</a> for a password suggestion.</span>
       </div>
 
       <BsForm @formLayout="horizontal" class="form-horizontal" @horizontalLabelGridClass="col-md-3" @model={{this.model}} @onSubmit={{action "submitAction"}} @submitOnEnter={{true}} as |form|>


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Removes the functionality that generated random password suggestions by calling the REST API.

Triggered by:
- the fact that the gem providing this doesn't work in the newer Ruby+Rails versions that @kaysiz is working on upgrading to
- the functionality hasn't been working well for a while
- in the days of ubiquitous password managers, this functionality is better provided at the user end

closes: https://github.com/datacite/product-backlog/issues/774

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
