### PR TITLE
Update caniuse-lite db in Fabrica - 2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7608,9 +7608,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001587:
-  version "1.0.30001731"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz"
-  integrity sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==
+  version "1.0.30001791"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz"
+  integrity sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Caniuse-lite helps Ember maintain browser compatibility by ensuring it is aware of various browser versions and their feature support.  It is used by Babel which Ember uses in its build process.  It is best to keep it up-to-date.  We are getting complaints during the build process that it needs to be updated:

<img width="1425" height="64" alt="Image" src="https://github.com/user-attachments/assets/128a0299-8991-4a1f-bc65-babed5f3a932" />

closes: https://github.com/datacite/bracco/issues/964

preview:  https://bracco-elgeevcfh-datacite.vercel.app/

## Approach
<!--- _How does this change address the problem?_ -->

Run the recommended command to do the update:

```
npx update-browserslist-db@latest
```

Since we use yarn classic there is no equivalent to this command in yarn.


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
